### PR TITLE
add 'name' attribute to high-level CUDS objects

### DIFF
--- a/simphony/cuds/abstractmesh.py
+++ b/simphony/cuds/abstractmesh.py
@@ -7,7 +7,13 @@ from abc import ABCMeta, abstractmethod
 
 
 class ABCMesh(object):
-    """Abstract base class for mesh."""
+    """Abstract base class for mesh.
+
+    Attributes
+    ----------
+    name : str
+        name of mesh
+    """
 
     __metaclass__ = ABCMeta
 

--- a/simphony/cuds/abstractparticles.py
+++ b/simphony/cuds/abstractparticles.py
@@ -10,7 +10,13 @@ from abc import ABCMeta, abstractmethod
 
 
 class ABCParticleContainer(object):
-    """Abstract base class for a ParticleContainer item."""
+    """Abstract base class for a ParticleContainer item.
+
+    Attributes
+    ----------
+    name : str
+        name of particle container
+    """
     __metaclass__ = ABCMeta
 
     @abstractmethod

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -186,8 +186,15 @@ class Mesh(ABCMesh):
     (4) inspection methods to identify if there are any edges,
         faces or cells described in the mesh.
 
+    Parameters
+    ----------
+    name : str
+        name of mesh
+
     Attributes
     ----------
+    name : str
+        name of mesh
     data : Data
         The X coordinate.
     points : dictionary of Point
@@ -209,7 +216,8 @@ class Mesh(ABCMesh):
 
     """
 
-    def __init__(self):
+    def __init__(self, name):
+        self.name = name
         self.data = 0
 
         self._points = {}

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -19,23 +19,33 @@ from simphony.core.data_container import DataContainer
 
 
 class ParticleContainer(ABCParticleContainer):
-    """Class that represents a container of particles and bonds. It can
-       add particles and bonds, remove them and update them.
+    """Class that represents a container of particles and bonds.
 
-       Attributes
-       ----------
+    Class provides methods to add particles and bonds, remove them and update
+    them.
 
-        _particles : dictionary
-            data structure for particles storage
-        _bonds : dictionary
-            data structure for bonds storage
-        data : DataContainer
-            data attributes of the element
+    Parameters
+    ----------
+    name : str
+        name of the particle container
+
+    Attributes
+    ----------
+    name : str
+        name of the particle container
+    _particles : dictionary
+        data structure for particles storage
+    _bonds : dictionary
+        data structure for bonds storage
+    data : DataContainer
+        data attributes of the element
+
     """
-    def __init__(self):
+    def __init__(self, name):
         self._particles = {}
         self._bonds = {}
         self.data = DataContainer()
+        self.name = name
 
 # ================================================================
 
@@ -77,7 +87,7 @@ class ParticleContainer(ABCParticleContainer):
         passing the Particle as parameter.
 
         >>> part = Particle()
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> part_container.add_particle(part)
         """
         return self._add_element(
@@ -117,7 +127,7 @@ class ParticleContainer(ABCParticleContainer):
         passing the Bond as parameter.
 
         >>> bond = Bond()
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> part_container.add_bond(bond)
         """
         return self._add_element(self._bonds, new_bond, Bond.from_bond)
@@ -150,7 +160,7 @@ class ParticleContainer(ABCParticleContainer):
         'get_particle' method for example) and a ParticleContainer just call
         the function passing the Particle as parameter.
 
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> ...
         >>> part = part_container.get_particle(id)
         >>> ... #do whatever you want with the particle
@@ -187,7 +197,7 @@ class ParticleContainer(ABCParticleContainer):
         'get_bond' method for example) and a ParticleContainer just call the
         function passing the Bond as parameter.
 
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> ...
         >>> bond = part_container.get_bond(id)
         >>> ... #do whatever you want with the bond
@@ -267,7 +277,7 @@ class ParticleContainer(ABCParticleContainer):
         --------
         Having an id of an existing particle, pass it to the function.
 
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> ...
         >>> part = part_container.get_particle(id)
         >>> ...
@@ -302,7 +312,7 @@ class ParticleContainer(ABCParticleContainer):
         --------
         Having an id of an existing bond, pass it to the function.
 
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> ...
         >>> bond = part_container.get_bond(id)
         >>> ...
@@ -348,7 +358,7 @@ class ParticleContainer(ABCParticleContainer):
         --------
         It can be used with a sequence as parameter or withouth it:
 
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> ...
         >>> for particle in part_container.iter_particles([id1, id2, id3]):
                 ...  #do stuff
@@ -399,7 +409,7 @@ class ParticleContainer(ABCParticleContainer):
         --------
         It can be used with a sequence as parameter or withouth it:
 
-        >>> part_container = ParticleContainer()
+        >>> part_container = ParticleContainer(name="foo")
         >>> ...
         >>> for bond in part_container.iter_bonds([id1, id2, id3]):
                 ...  #do stuff

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -24,7 +24,7 @@ class TestSequenceFunctions(unittest.TestCase):
         to tests all the mesh methods
 
         """
-        self.mesh = Mesh()
+        self.mesh = Mesh(name="foo")
         self.points = [
             Point((0.0, 0.0, 0.0)),
             Point((1.0, 0.0, 0.0)),

--- a/simphony/cuds/tests/test_particlesclasses.py
+++ b/simphony/cuds/tests/test_particlesclasses.py
@@ -64,7 +64,7 @@ class ParticleContainerAddParticlesTestCase(unittest.TestCase):
         self.p_list = []
         for i in xrange(10):
             self.p_list.append(Particle([i, i*10, i*100]))
-        self.pc = ParticleContainer()
+        self.pc = ParticleContainer(name="foo")
 
     def test_has_particle(self):
         id = self.pc.add_particle(self.p_list[0])
@@ -88,7 +88,7 @@ class ParticleContainerAddParticlesTestCase(unittest.TestCase):
 class ParticleContainerManipulatingParticlesTestCase(unittest.TestCase):
     def setUp(self):
         self.p_list = []
-        self.pc = ParticleContainer()
+        self.pc = ParticleContainer(name="foo")
         for i in xrange(10):
             particle = Particle([i, i*10, i*100], id=uuid.UUID(int=i))
             self.p_list.append(particle)
@@ -152,7 +152,7 @@ class ParticleContainerAddBondsTestCase(unittest.TestCase):
                     uuid.UUID(int=i),
                     uuid.UUID(int=i + 1),
                     uuid.UUID(int=i+2)]))
-        self.pc = ParticleContainer()
+        self.pc = ParticleContainer(name="foo")
 
     def test_has_bond(self):
         id = self.pc.add_bond(self.b_list[0])
@@ -176,7 +176,7 @@ class ParticleContainerManipulatingBondsTestCase(unittest.TestCase):
     def setUp(self):
         self.p_list = []
         self.b_list = []
-        self.pc = ParticleContainer()
+        self.pc = ParticleContainer(name="foo")
         for i in xrange(10):
             self.p_list.append(Particle([i, i*10, i*100]))
             self.b_list.append(Bond([1, 2, 3]))

--- a/simphony/io/file_particle_container.py
+++ b/simphony/io/file_particle_container.py
@@ -42,6 +42,14 @@ class FileParticleContainer(ABCParticleContainer):
             # create table to hold bonds
             self._create_bonds_table()
 
+    @property
+    def name(self):
+        return self._group._v_name
+
+    @name.setter
+    def name(self, value):
+        self._group._f_rename(value)
+
     # Particle methods ######################################################
 
     def add_particle(self, particle):

--- a/simphony/io/tests/test_file_particle_container.py
+++ b/simphony/io/tests/test_file_particle_container.py
@@ -4,7 +4,7 @@ import tempfile
 import shutil
 import unittest
 
-from simphony.cuds.particles import Particle, Bond
+from simphony.cuds.particles import ParticleContainer, Particle, Bond
 from simphony.io.cuds_file import CudsFile
 
 
@@ -31,7 +31,8 @@ class TestFileParticleContainer(unittest.TestCase):
         # create file with empty particle container
         self.filename = os.path.join(self.temp_dir, 'test_file.cuds')
         self.file = CudsFile.open(self.filename)
-        self.pc = self.file.add_particle_container("test")
+        self.pc = self.file.add_particle_container(
+            ParticleContainer(name="test"))
 
         # create two particles (with unique ids)
         self.particle_1 = Particle((0.1, 0.4, 5.0), id=0)


### PR DESCRIPTION
This addresses #38.  A read/write `name` attribute is added to high-level CUDS objects.  This `name` is now used by CudsFile (get_particle_container...etc).

- [x] add 'name' attribute to Mesh
- [x] add 'name' attribute to ParticleContainer 
- [x] add 'name' attribute to FileParticleContainer
- [x] use 'name' of particle container in CudsFile