### PR TITLE
Use uuid hex instead of bytes in data table

### DIFF
--- a/simphony/core/cuba.yml
+++ b/simphony/core/cuba.yml
@@ -1,9 +1,9 @@
-- description: Universal unique id
+- description: Universal unique id represented as a hex string size 32
   domain: [ATM, DEM, FEM, FVM, LBM, SPH, VIS]
   key: ID
   name: Id
   number: 0
-  shape: [16]
+  shape: [32]
   type: string
 - description: Naming of high-level objects (e.g. solver models)
   domain: [ATM, DEM, FEM, FVM, LBM, SPH, VIS]

--- a/simphony/io/data_container_description.py
+++ b/simphony/io/data_container_description.py
@@ -74,7 +74,7 @@ class Data(tables.IsDescription):
 
 class Record(tables.IsDescription):
 
-    index = tables.StringCol(itemsize=16, pos=0)
+    index = tables.StringCol(itemsize=32, pos=0)
     data = Data()
     mask = tables.BoolCol(pos=1, shape=(66,))
 

--- a/simphony/io/data_container_table.py
+++ b/simphony/io/data_container_table.py
@@ -79,7 +79,7 @@ class DataContainerTable(MutableMapping):
         table = self._table
         uid = uuid.uuid4()
         row = table.row
-        row['index'] = uid.bytes
+        row['index'] = uid.hex
         self._populate(row, data)
         row.append()
         table.flush()
@@ -90,7 +90,7 @@ class DataContainerTable(MutableMapping):
 
         """
         for row in self._table.where(
-                'index == value',  condvars={'value': uid.bytes}):
+                'index == value',  condvars={'value': uid.hex}):
             return self._retrieve(row)
         else:
             raise KeyError(
@@ -102,7 +102,7 @@ class DataContainerTable(MutableMapping):
         """
         table = self._table
         for row in table.where(
-                'index == value', condvars={'value': uid.bytes}):
+                'index == value', condvars={'value': uid.hex}):
             self._populate(row, data)
             row.update()
             # see https://github.com/PyTables/PyTables/issues/11
@@ -110,7 +110,7 @@ class DataContainerTable(MutableMapping):
             return
         else:
             row = table.row
-            row['index'] = uid.bytes
+            row['index'] = uid.hex
             self._populate(row, data)
             row.append()
             table.flush()
@@ -121,7 +121,7 @@ class DataContainerTable(MutableMapping):
         """
         table = self._table
         for row in table.where(
-                'index == value', condvars={'value': uid.bytes}):
+                'index == value', condvars={'value': uid.hex}):
             if table.nrows == 1:
                 name = table._v_name
                 record = table.description

--- a/simphony/io/tests/test_data_container_table.py
+++ b/simphony/io/tests/test_data_container_table.py
@@ -23,7 +23,7 @@ class CustomData(tables.IsDescription):
 
 class CustomRecord(tables.IsDescription):
 
-    index = tables.StringCol(itemsize=16, pos=0)
+    index = tables.StringCol(itemsize=32, pos=0)
     data = CustomData()
     mask = tables.BoolCol(pos=1, shape=(8,))
 

--- a/simphony/scripts/cuba_generate.py
+++ b/simphony/scripts/cuba_generate.py
@@ -88,7 +88,7 @@ def table(input, output):
     lines.extend([
         'class Record(tables.IsDescription):\n',
         '\n',
-        '    index = tables.StringCol(itemsize=16, pos=0)\n',
+        '    index = tables.StringCol(itemsize=32, pos=0)\n',
         '    data = Data()\n',
         '    mask = tables.BoolCol(pos=1, shape=({},))\n'.format(mask_size),
         '\n\n'])


### PR DESCRIPTION
This PR updates the uuid based data container Table to use the `hex` representation of the uuid (see #55) for an explenation of the problems with `bytes`