### PR TITLE
Use uid instead of id or uuid

### DIFF
--- a/simphony/cuds/abstractmesh.py
+++ b/simphony/cuds/abstractmesh.py
@@ -18,19 +18,19 @@ class ABCMesh(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get_point(self, uuid):
+    def get_point(self, uid):
         pass
 
     @abstractmethod
-    def get_edge(self, uuid):
+    def get_edge(self, uid):
         pass
 
     @abstractmethod
-    def get_face(self, uuid):
+    def get_face(self, uid):
         pass
 
     @abstractmethod
-    def get_cell(self, uuid):
+    def get_cell(self, uid):
         pass
 
     @abstractmethod

--- a/simphony/cuds/abstractparticles.py
+++ b/simphony/cuds/abstractparticles.py
@@ -36,35 +36,35 @@ class ABCParticleContainer(object):
         pass
 
     @abstractmethod
-    def get_particle(self, particle_id):
+    def get_particle(self, uid):
         pass
 
     @abstractmethod
-    def get_bond(self, bond_id):
+    def get_bond(self, uid):
         pass
 
     @abstractmethod
-    def remove_particle(self, particle_id):
+    def remove_particle(self, uid):
         pass
 
     @abstractmethod
-    def remove_bond(self, bond_id):
+    def remove_bond(self, uid):
         pass
 
     @abstractmethod
-    def iter_particles(self, particle_ids=None):
+    def iter_particles(self, uids=None):
         pass
 
     @abstractmethod
-    def iter_bonds(self, bond_ids=None):
+    def iter_bonds(self, uids=None):
         pass
 
     @abstractmethod
-    def has_particle(self, id):
+    def has_particle(self, uid):
         pass
 
     @abstractmethod
-    def has_bond(self, id):
+    def has_bond(self, uid):
         pass
 
 

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -17,7 +17,7 @@ class Point(object):
 
     Parameters
     ----------
-    uuid :
+    uid :
         uuid of the point.
     coordinates : list of double
         set of coordinates (x,y,z) describing the point position.
@@ -26,7 +26,7 @@ class Point(object):
 
     Attributes
     ----------
-    uuid :
+    uid :
         uuid of the point.
     data : DataContainer
         object to store point data
@@ -35,8 +35,8 @@ class Point(object):
 
     """
 
-    def __init__(self, coordinates, uuid=None, data=None):
-        self.uuid = uuid
+    def __init__(self, coordinates, uid=None, data=None):
+        self.uid = uid
         self.coordinates = tuple(coordinates)
 
         if data:
@@ -48,7 +48,7 @@ class Point(object):
     def from_point(cls, point):
         return cls(
             point.coordinates,
-            point.uuid,
+            point.uid,
             point.data
         )
 
@@ -60,7 +60,7 @@ class Element(object):
 
     Parameters
     ----------
-    uuid :
+    uid :
         uuid of the edge.
     points : list of Point
         list of points defining the edge.
@@ -69,7 +69,7 @@ class Element(object):
 
     Attributes
     ----------
-    uuid :
+    uid :
         uuid of the element
     data : DataContainer
         Element data
@@ -78,8 +78,8 @@ class Element(object):
 
     """
 
-    def __init__(self, points, uuid=None, data=None):
-        self.uuid = uuid
+    def __init__(self, points, uid=None, data=None):
+        self.uid = uid
         self.points = points[:]
 
         if data:
@@ -91,7 +91,7 @@ class Element(object):
     def from_element(cls, element):
         return cls(
             element.points,
-            element.uuid,
+            element.uid,
             element.data
         )
 
@@ -116,7 +116,7 @@ class Edge(Element):
     def from_edge(cls, edge):
         return cls(
             edge.points,
-            edge.uuid,
+            edge.uid,
             edge.data
         )
 
@@ -141,7 +141,7 @@ class Face(Element):
     def from_face(cls, face):
         return cls(
             face.points,
-            face.uuid,
+            face.uid,
             face.data
         )
 
@@ -166,7 +166,7 @@ class Cell(Element):
     def from_cell(cls, cell):
         return cls(
             cell.points,
-            cell.uuid,
+            cell.uid,
             cell.data
         )
 
@@ -364,17 +364,17 @@ class Mesh(ABCMesh):
 
         """
 
-        if point.uuid is None:
-            point.uuid = self._generate_uuid()
+        if point.uid is None:
+            point.uid = self._generate_uuid()
 
-        if point.uuid in self._points:
+        if point.uid in self._points:
             error_str = "Trying to add an already existing point with uuid: "\
-                + str(point.uuid)
+                + str(point.uid)
             raise KeyError(error_str)
 
-        self._points[point.uuid] = Point.from_point(point)
+        self._points[point.uid] = Point.from_point(point)
 
-        return point.uuid
+        return point.uid
 
     def add_edge(self, edge):
         """ Adds a new edge to the mesh.
@@ -395,17 +395,17 @@ class Mesh(ABCMesh):
 
         """
 
-        if edge.uuid is None:
-            edge.uuid = self._generate_uuid()
+        if edge.uid is None:
+            edge.uid = self._generate_uuid()
 
-        if edge.uuid in self._edges:
+        if edge.uid in self._edges:
             error_str = "Trying to add an already existing edge with uuid: "\
-                + str(edge.uuid)
+                + str(edge.uid)
             raise KeyError(error_str)
 
-        self._edges[edge.uuid] = Edge.from_edge(edge)
+        self._edges[edge.uid] = Edge.from_edge(edge)
 
-        return edge.uuid
+        return edge.uid
 
     def add_face(self, face):
         """ Adds a new face to the mesh.
@@ -426,17 +426,17 @@ class Mesh(ABCMesh):
 
         """
 
-        if face.uuid is None:
-            face.uuid = self._generate_uuid()
+        if face.uid is None:
+            face.uid = self._generate_uuid()
 
-        if face.uuid in self._faces:
+        if face.uid in self._faces:
             error_str = "Trying to add an already existing face with uuid: "\
-                + str(face.uuid)
+                + str(face.uid)
             raise KeyError(error_str)
 
-        self._faces[face.uuid] = Face.from_face(face)
+        self._faces[face.uid] = Face.from_face(face)
 
-        return face.uuid
+        return face.uid
 
     def add_cell(self, cell):
         """ Adds a new cell to the mesh.
@@ -457,17 +457,17 @@ class Mesh(ABCMesh):
 
         """
 
-        if cell.uuid is None:
-            cell.uuid = self._generate_uuid()
+        if cell.uid is None:
+            cell.uid = self._generate_uuid()
 
-        if cell.uuid in self._cells:
+        if cell.uid in self._cells:
             error_str = "Trying to add an already existing cell with uuid: "\
-                + str(cell.uuid)
+                + str(cell.uid)
             raise KeyError(error_str)
 
-        self._cells[cell.uuid] = Cell.from_cell(cell)
+        self._cells[cell.uid] = Cell.from_cell(cell)
 
-        return cell.uuid
+        return cell.uid
 
     def update_point(self, point):
         """ Updates the information of a point.
@@ -491,9 +491,9 @@ class Mesh(ABCMesh):
 
         """
 
-        if point.uuid not in self._points:
+        if point.uid not in self._points:
             error_str = "Trying to update a non-existing point with uuid: "\
-                + str(point.uuid)
+                + str(point.uid)
             raise KeyError(error_str)
 
         if not isinstance(point, Point):
@@ -501,7 +501,7 @@ class Mesh(ABCMesh):
                 + "Point expected."
             raise TypeError(error_str)
 
-        point_to_update = self._points[point.uuid]
+        point_to_update = self._points[point.uid]
 
         point_to_update.data = point.data
         point_to_update.coordinates = point.coordinates
@@ -528,9 +528,9 @@ class Mesh(ABCMesh):
 
         """
 
-        if edge.uuid not in self._edges:
+        if edge.uid not in self._edges:
             error_str = "Trying to update a non-existing edge with uuid: "\
-                + str(edge.uuid)
+                + str(edge.uid)
             raise KeyError(error_str)
 
         if not isinstance(edge, Edge):
@@ -538,7 +538,7 @@ class Mesh(ABCMesh):
                 + "Edge expected."
             raise TypeError(error_str)
 
-        edge_to_update = self._edges[edge.uuid]
+        edge_to_update = self._edges[edge.uid]
 
         edge_to_update.data = edge.data
         edge_to_update.points = edge.points
@@ -565,9 +565,9 @@ class Mesh(ABCMesh):
 
         """
 
-        if face.uuid not in self._faces:
+        if face.uid not in self._faces:
             error_str = "Trying to update a non-existing face with uuid: "\
-                + str(face.uuid)
+                + str(face.uid)
             raise KeyError(error_str)
 
         if not isinstance(face, Face):
@@ -575,7 +575,7 @@ class Mesh(ABCMesh):
                 + "Face expected."
             raise TypeError(error_str)
 
-        face_to_update = self._faces[face.uuid]
+        face_to_update = self._faces[face.uid]
 
         face_to_update.data = face.data
         face_to_update.points = face.points
@@ -602,9 +602,9 @@ class Mesh(ABCMesh):
 
         """
 
-        if cell.uuid not in self._cells:
+        if cell.uid not in self._cells:
             error_str = "Trying to update a non-existing cell with uuid: "\
-                + str(cell.uuid)
+                + str(cell.uid)
             raise KeyError(error_str)
 
         if not isinstance(cell, Cell):
@@ -612,7 +612,7 @@ class Mesh(ABCMesh):
                 + "Cell expected."
             raise TypeError(error_str)
 
-        cell_to_update = self._cells[cell.uuid]
+        cell_to_update = self._cells[cell.uid]
 
         cell_to_update.data = cell.data
         cell_to_update.points = cell.points

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -53,8 +53,8 @@ class ParticleContainer(ABCParticleContainer):
 
 # ================================================================
 
-    def add_particle(self, new_particle):
-        """Adds the 'new_particle' particle to the container.
+    def add_particle(self, particle):
+        """Adds the particle to the container.
 
         If the new particle has no id, the particle container
         will generate a new unique id for it. If the particle has
@@ -65,12 +65,12 @@ class ParticleContainer(ABCParticleContainer):
 
         Parameters
         ----------
-        new_particle : Particle
+        particle : Particle
             the new particle that will be included in the container.
 
         Returns
         -------
-        id : uuid.UUID
+        uid : uuid.UID
             The id of the added particle.
 
         Raises
@@ -91,10 +91,10 @@ class ParticleContainer(ABCParticleContainer):
         >>> part_container.add_particle(part)
         """
         return self._add_element(
-            self._particles, new_particle, clone=Particle.from_particle)
+            self._particles, particle, clone=Particle.from_particle)
 
-    def add_bond(self, new_bond):
-        """Adds the 'new_bond' bond to the container.
+    def add_bond(self, bond):
+        """Adds the bond to the container.
 
         Also like with particles, if the bond has an user defined id,
         it won't add the bond if a bond with the same id already exists, and
@@ -110,7 +110,7 @@ class ParticleContainer(ABCParticleContainer):
 
         Returns
         -------
-        id : uuid.UUID
+        uid : uuid.UID
             The id of the added bond.
 
         Raises
@@ -130,10 +130,10 @@ class ParticleContainer(ABCParticleContainer):
         >>> part_container = ParticleContainer(name="foo")
         >>> part_container.add_bond(bond)
         """
-        return self._add_element(self._bonds, new_bond, Bond.from_bond)
+        return self._add_element(self._bonds, bond, Bond.from_bond)
 
     def update_particle(self, particle):
-        """Replaces an existing particle with the 'particle' new particle.
+        """Replaces an existing particle.
 
         Takes the id of 'particle' and searchs inside the container for
         that particle. If the particle exists, it is replaced with the new
@@ -162,7 +162,7 @@ class ParticleContainer(ABCParticleContainer):
 
         >>> part_container = ParticleContainer(name="foo")
         >>> ...
-        >>> part = part_container.get_particle(id)
+        >>> part = part_container.get_particle(uid)
         >>> ... #do whatever you want with the particle
         >>> part_container.update_particle(part)
         """
@@ -170,7 +170,7 @@ class ParticleContainer(ABCParticleContainer):
             self._particles, particle, clone=Particle.from_particle)
 
     def update_bond(self, bond):
-        """Replaces an existing bond with the 'bond' new bond.
+        """Replaces an existing bond.
 
         Takes the id of 'bond' and searchs inside the container for
         that bond. If the bond exists, it is replaced with the new
@@ -199,19 +199,19 @@ class ParticleContainer(ABCParticleContainer):
 
         >>> part_container = ParticleContainer(name="foo")
         >>> ...
-        >>> bond = part_container.get_bond(id)
+        >>> bond = part_container.get_bond(uid)
         >>> ... #do whatever you want with the bond
         >>> part_container.update_bond(bond)
         """
         self._update_element(self._bonds, bond, clone=Bond.from_bond)
 
-    def get_particle(self, particle_id):
+    def get_particle(self, uid):
         """Returns a copy of the particle with the 'particle_id' id.
 
         Parameters
         ----------
 
-        particle_id : uint32
+        uid : uuid.UUID
             the id of the particle
 
         Raises
@@ -223,19 +223,19 @@ class ParticleContainer(ABCParticleContainer):
         A copy of the particle
         """
         try:
-            particle = self._particles[particle_id]
+            particle = self._particles[uid]
         except KeyError:
             raise KeyError(
-                'Particle with id {} not found!'.format(particle_id))
+                'Particle with id {} not found!'.format(uid))
         return Particle.from_particle(particle)
 
-    def get_bond(self, bond_id):
+    def get_bond(self, uid):
         """Returns a copy of the bond with the 'bond_id' id.
 
         Parameters
         ----------
 
-        bond_id : uint32
+        uid : uuid.UUID
             the id of the bond
 
         Raises
@@ -247,14 +247,14 @@ class ParticleContainer(ABCParticleContainer):
         A copy of the bond
         """
         try:
-            bond = self._bonds[bond_id]
+            bond = self._bonds[uid]
         except KeyError:
             raise KeyError(
-                'Bond with id {} not found!'.format(bond_id))
+                'Bond with id {} not found!'.format(uid))
         return Bond.from_bond(bond)
 
-    def remove_particle(self, particle_id):
-        """Removes the particle with the 'particle_id' id from the container.
+    def remove_particle(self, uid):
+        """Removes the particle with uid from the container.
 
         The id passed as parameter should exists in the container. Otherwise
         an expcetion will be raised.
@@ -262,7 +262,7 @@ class ParticleContainer(ABCParticleContainer):
         Parameters
         ----------
 
-        particle_id : Particle
+       uid : uuid.UUID
             the id of the particle to be removed.
 
         Raises
@@ -279,21 +279,21 @@ class ParticleContainer(ABCParticleContainer):
 
         >>> part_container = ParticleContainer(name="foo")
         >>> ...
-        >>> part = part_container.get_particle(id)
+        >>> part = part_container.get_particle(uid)
         >>> ...
-        >>> part_container.remove_particle(part.id)
+        >>> part_container.remove_particle(part.uid)
         or directly
-        >>> part_container.remove_particle(id)
+        >>> part_container.remove_particle(uid)
         """
 
         try:
-            self._remove_element(self._particles, particle_id)
+            self._remove_element(self._particles, uid)
         except KeyError:
             raise KeyError(
-                'Particle with id { } not found!'.format(particle_id))
+                'Particle with id { } not found!'.format(uid))
 
-    def remove_bond(self, bond_id):
-        """Removes the bond with the 'bond_id' id from the container.
+    def remove_bond(self, uid):
+        """Removes the bond with the uid from the container.
 
         The id passed as parameter should exists in the container. If
         it doesn't exists, nothing will happen.
@@ -301,7 +301,7 @@ class ParticleContainer(ABCParticleContainer):
         Parameters
         ----------
 
-        bond_id : Bond
+        uid : uuid.UUID
             the id of the bond to be removed.
 
         See Also
@@ -316,18 +316,18 @@ class ParticleContainer(ABCParticleContainer):
         >>> ...
         >>> bond = part_container.get_bond(id)
         >>> ...
-        >>> part_container.remove_bond(bond.id)
+        >>> part_container.remove_bond(bond.uid)
         or directly
         >>> part_container.remove_bond(id)
         """
 
         try:
-            self._remove_element(self._bonds, bond_id)
+            self._remove_element(self._bonds, uid)
         except KeyError:
             raise KeyError(
-                'Bond with id { } not found!'.format(bond_id))
+                'Bond with id { } not found!'.format(uid))
 
-    def iter_particles(self, particle_ids=None):
+    def iter_particles(self, ids=None):
         """Generator method for iterating over the particles of the container.
 
         It can recieve any kind of sequence of particle ids to iterate over
@@ -337,7 +337,7 @@ class ParticleContainer(ABCParticleContainer):
         Parameters
         ----------
 
-        particle_ids : array_like
+        ids : iterable
             sequence containing the id's of the particles that will be
             iterated.
 
@@ -372,14 +372,14 @@ class ParticleContainer(ABCParticleContainer):
                 #in case we need it
                 part_container.update_particle(particle)
         """
-        if particle_ids is not None:
+        if ids is not None:
             return self._iter_elements(
-                self._particles, particle_ids, clone=Particle.from_particle)
+                self._particles, ids, clone=Particle.from_particle)
         else:
             return self._iter_all(
                 self._particles, clone=Particle.from_particle)
 
-    def iter_bonds(self, bond_ids=None):
+    def iter_bonds(self, ids=None):
         """Generator method for iterating over the bonds of the container.
 
         It can recieve any kind of sequence of bond ids to iterate over
@@ -424,21 +424,21 @@ class ParticleContainer(ABCParticleContainer):
                 part_container.update_bond(bond)
         """
 
-        if bond_ids is not None:
+        if ids is not None:
             return self._iter_elements(
-                self._bonds, bond_ids, clone=Bond.from_bond)
+                self._bonds, ids, clone=Bond.from_bond)
         else:
             return self._iter_all(self._bonds, clone=Bond.from_bond)
 
-    def has_particle(self, id):
+    def has_particle(self, uid):
         """Checks if a particle with the given id already exists
         in the container."""
-        return id in self._particles
+        return uid in self._particles
 
-    def has_bond(self, id):
+    def has_bond(self, uid):
         """Checks if a bond with the given id already exists
         in the container."""
-        return id in self._bonds
+        return uid in self._bonds
 
 # ================================================================
 
@@ -459,10 +459,10 @@ class ParticleContainer(ABCParticleContainer):
 
     def _add_element(self, cur_dict, element, clone):
         # We check if the current dictionary has the element
-        cur_id = element.id
+        cur_id = element.uid
         if cur_id is None:
             cur_id = uuid.uuid4()
-            element.id = cur_id
+            element.uid = cur_id
             cur_dict[cur_id] = clone(element)
         else:
             if cur_id not in cur_dict:
@@ -475,7 +475,7 @@ class ParticleContainer(ABCParticleContainer):
         return cur_id
 
     def _update_element(self, cur_dict, element, clone):
-        cur_id = element.id
+        cur_id = element.uid
         if cur_id in cur_dict:
             # This means the element IS in the current dictionary
             # (this should be the standard case...), so we proceed
@@ -498,7 +498,7 @@ class Particle(object):
 
     Attributes
     ----------
-        id : uint32
+        uid : uuid.UUID
             the unique id of the particle
         coordinates : list / tuple
             x,y,z coordinates of the particle
@@ -507,20 +507,20 @@ class Particle(object):
 
     """
 
-    def __init__(self, coordinates=(0.0, 0.0, 0.0), id=None, data=None):
+    def __init__(self, coordinates=(0.0, 0.0, 0.0), uid=None, data=None):
         """ Create a Particle.
 
         Parameters
         ----------
         coordinates : list / tuple
             x,y,z coordinates of the particle (Default: [0, 0, 0])
-        id : uuid.UUID
+        uid : uuid.UID
             the id, None as default (the particle container will generate it)
         data : DataContainer
             the data, the particle will have a copy of this
         """
 
-        self.id = id
+        self.uid = uid
         self.coordinates = tuple(coordinates)
         if data is None:
             self.data = DataContainer()
@@ -530,12 +530,12 @@ class Particle(object):
     @classmethod
     def from_particle(cls, particle):
         return cls(
-            id=uuid.UUID(bytes=particle.id.bytes),
+            uid=uuid.UUID(bytes=particle.uid.bytes),
             coordinates=particle.coordinates,
             data=DataContainer(particle.data))
 
     def __str__(self):
-        total_str = "{0}_{1}".format(self.id, self.coordinates)
+        total_str = "{0}_{1}".format(self.uid, self.coordinates)
         return total_str
 
 
@@ -544,7 +544,7 @@ class Bond(object):
 
     Attributes
     ----------
-        id : uuid
+        uid : uuid.UUID
             the unique id of the bond
         particles : tuple
             tuple of uuids of the particles that are participating in the bond.
@@ -553,20 +553,20 @@ class Bond(object):
 
     """
 
-    def __init__(self, particles, id=None, data=None):
+    def __init__(self, particles, uid=None, data=None):
         """ Create a Bond.
 
         Parameters
         ----------
         particles : sequence
             list of particles of the bond. It can not be empty.
-        id : uuid.UUID
+        uid : uuid.UUID
             the id, None as default (the particle container will generate it)
         data : DataContainer
             DataContainer to store the attributes of the bond
 
         """
-        self.id = id
+        self.uid = uid
         if particles is not None and len(particles) > 0:
             self.particles = tuple(particles)
         else:
@@ -581,11 +581,11 @@ class Bond(object):
     def from_bond(cls, bond):
         return cls(
             particles=bond.particles,
-            id=uuid.UUID(bytes=bond.id.bytes),
+            uid=uuid.UUID(bytes=bond.uid.bytes),
             data=DataContainer(bond.data))
 
     def __str__(self):
-        total_str = "{0}_{1}".format(self.id, self.particles)
+        total_str = "{0}_{1}".format(self.uid, self.particles)
         return total_str
 
 

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -487,12 +487,12 @@ class Particle(object):
 
     Attributes
     ----------
-        uid : uuid.UUID
-            the unique id of the particle
-        coordinates : list / tuple
-            x,y,z coordinates of the particle
-        data : DataContainer
-            DataContainer to store the attributes of the particle
+    uid : uuid.UUID
+        the unique id of the particle
+    coordinates : list / tuple
+        x,y,z coordinates of the particle
+    data : DataContainer
+        DataContainer to store the attributes of the particle
 
     """
 

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -232,7 +232,7 @@ class TestSequenceFunctions(unittest.TestCase):
         point_ret = self.mesh.get_point(puuids[0])
 
         self.assertTrue(isinstance(point_ret, Point))
-        self.assertEqual(puuids[0], point_ret.uuid)
+        self.assertEqual(puuids[0], point_ret.uid)
 
     def test_get_edge(self):
         """ Check that an edge can be retrieved correctly
@@ -259,7 +259,7 @@ class TestSequenceFunctions(unittest.TestCase):
         edge_ret = self.mesh.get_edge(euuids[0])
 
         self.assertTrue(isinstance(edge_ret, Edge))
-        self.assertEqual(euuids[0], edge_ret.uuid)
+        self.assertEqual(euuids[0], edge_ret.uid)
 
     def test_get_face(self):
         """ Check that a face can be retrieved correctly
@@ -287,7 +287,7 @@ class TestSequenceFunctions(unittest.TestCase):
         face_ret = self.mesh.get_face(fuuids[0])
 
         self.assertTrue(isinstance(face_ret, Face))
-        self.assertEqual(fuuids[0], face_ret.uuid)
+        self.assertEqual(fuuids[0], face_ret.uid)
 
     def test_get_cell(self):
         """ Check that a cell can be retrieved correctly
@@ -316,7 +316,7 @@ class TestSequenceFunctions(unittest.TestCase):
         cell_ret = self.mesh.get_cell(cuuids[0])
 
         self.assertTrue(isinstance(cell_ret, Cell))
-        self.assertEqual(cuuids[0], cell_ret.uuid)
+        self.assertEqual(cuuids[0], cell_ret.uid)
 
     def test_get_all_edges_iterator(self):
         """ Checks the edge iterator
@@ -352,7 +352,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
         iedges = self.mesh.iter_edges()
 
-        iedges_id = [edge.uuid for edge in iedges]
+        iedges_id = [edge.uid for edge in iedges]
 
         self.assertItemsEqual(iedges_id, euuids)
 
@@ -391,7 +391,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
         ifaces = self.mesh.iter_faces()
 
-        ifaces_id = [face.uuid for face in ifaces]
+        ifaces_id = [face.uid for face in ifaces]
 
         self.assertItemsEqual(fuuids, ifaces_id)
 
@@ -431,7 +431,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
         icells = self.mesh.iter_cells()
 
-        icells_id = [cell.uuid for cell in icells]
+        icells_id = [cell.uid for cell in icells]
 
         self.assertItemsEqual(icells_id, cuuids)
 
@@ -472,7 +472,7 @@ class TestSequenceFunctions(unittest.TestCase):
         iedges = self.mesh.iter_edges([euuids[0], euuids[2]])
 
         source_id = [euuids[0], euuids[2]]
-        iedges_id = [edge.uuid for edge in iedges]
+        iedges_id = [edge.uid for edge in iedges]
 
         self.assertItemsEqual(source_id, iedges_id)
 
@@ -514,7 +514,7 @@ class TestSequenceFunctions(unittest.TestCase):
         ifaces = self.mesh.iter_faces([fuuids[0], fuuids[2]])
 
         source_id = [fuuids[0], fuuids[2]]
-        ifaces_id = [face.uuid for face in ifaces]
+        ifaces_id = [face.uid for face in ifaces]
 
         self.assertItemsEqual(source_id, ifaces_id)
 
@@ -557,7 +557,7 @@ class TestSequenceFunctions(unittest.TestCase):
         icells = self.mesh.iter_cells([cuuids[0], cuuids[2]])
 
         source_id = [cuuids[0], cuuids[2]]
-        icells_id = [cell.uuid for cell in icells]
+        icells_id = [cell.uid for cell in icells]
 
         self.assertItemsEqual(source_id, icells_id)
 

--- a/simphony/cuds/tests/test_particlesclasses.py
+++ b/simphony/cuds/tests/test_particlesclasses.py
@@ -17,7 +17,7 @@ class ParticleTestCase(unittest.TestCase):
         particle = Particle()
         self.assertIsInstance(particle, Particle)
         self.assertEqual(particle.coordinates, (0, 0, 0))
-        self.assertEqual(particle.id, None)
+        self.assertEqual(particle.uid, None)
         self.assertEqual(particle.data, DataContainer())
 
     def test_simple_particle_custom(self):
@@ -26,12 +26,12 @@ class ParticleTestCase(unittest.TestCase):
         particle = Particle([20.5, 30.5, 40.5], uuid.UUID(int=33), data)
         self.assertIsInstance(particle, Particle)
         self.assertEqual(particle.coordinates, (20.5, 30.5, 40.5))
-        self.assertEqual(particle.id, uuid.UUID(int=33))
+        self.assertEqual(particle.uid, uuid.UUID(int=33))
         self.assertEqual(particle.data, data)
 
     def test_str(self):
         particle = Particle()
-        total_str = str(particle.id) + '_' + str(particle.coordinates)
+        total_str = str(particle.uid) + '_' + str(particle.coordinates)
         self.assertEqual(str(particle), total_str)
 
 
@@ -44,7 +44,7 @@ class BondTestCase(unittest.TestCase):
         bond = Bond(uuids, uuid.UUID(int=12), data)
         self.assertIsInstance(bond, Bond)
         self.assertEqual(bond.particles, tuple(uuids))
-        self.assertEqual(bond.id,  uuid.UUID(int=12))
+        self.assertEqual(bond.uid,  uuid.UUID(int=12))
         self.assertEqual(bond.particles, tuple(uuids))
         self.assertEqual(bond.data, data)
 
@@ -55,7 +55,7 @@ class BondTestCase(unittest.TestCase):
     def test_str(self):
         uuids = [uuid.UUID(int=i) for i in range(3)]
         bond = Bond(particles=uuids)
-        total_str = str(bond.id) + '_' + str(tuple(uuids))
+        total_str = str(bond.uid) + '_' + str(tuple(uuids))
         self.assertEqual(str(bond), total_str)
 
 
@@ -67,16 +67,16 @@ class ParticleContainerAddParticlesTestCase(unittest.TestCase):
         self.pc = ParticleContainer(name="foo")
 
     def test_has_particle(self):
-        id = self.pc.add_particle(self.p_list[0])
-        self.assertTrue(self.pc.has_particle(id))
+        uid = self.pc.add_particle(self.p_list[0])
+        self.assertTrue(self.pc.has_particle(uid))
         self.assertFalse(self.pc.has_particle(uuid.UUID(int=1234)))
 
     def test_add_particle_ok(self):
         ids = [
             self.pc.add_particle(particle) for particle in self.p_list]
         for index, particle in enumerate(self.p_list):
-            self.assertTrue(self.pc.has_particle(particle.id))
-            self.assertEqual(particle.id, ids[index])
+            self.assertTrue(self.pc.has_particle(particle.uid))
+            self.assertEqual(particle.uid, ids[index])
 
     def test_exception_when_adding_particle_twice(self):
         for particle in self.p_list:
@@ -90,18 +90,18 @@ class ParticleContainerManipulatingParticlesTestCase(unittest.TestCase):
         self.p_list = []
         self.pc = ParticleContainer(name="foo")
         for i in xrange(10):
-            particle = Particle([i, i*10, i*100], id=uuid.UUID(int=i))
+            particle = Particle([i, i*10, i*100], uid=uuid.UUID(int=i))
             self.p_list.append(particle)
             self.pc.add_particle(particle)
 
     def test_update_particle(self):
-        particle = self.pc.get_particle(self.p_list[1].id)
+        particle = self.pc.get_particle(self.p_list[1].uid)
         particle.coordinates = (123, 456, 789)
         part_coords = particle.coordinates
         self.pc.update_particle(particle)
-        new_particle = self.pc.get_particle(particle.id)
+        new_particle = self.pc.get_particle(particle.uid)
         self.assertTrue(new_particle is not particle)
-        self.assertEqual(particle.id, new_particle.id)
+        self.assertEqual(particle.uid, new_particle.uid)
         self.assertEqual(part_coords, new_particle.coordinates)
         self.assertEqual(particle.data, new_particle.data)
 
@@ -112,34 +112,34 @@ class ParticleContainerManipulatingParticlesTestCase(unittest.TestCase):
 
     def test_remove_particle(self):
         particle = self.p_list[0]
-        self.pc.remove_particle(particle.id)
-        self.assertFalse(self.pc.has_particle(particle.id))
+        self.pc.remove_particle(particle.uid)
+        self.assertFalse(self.pc.has_particle(particle.uid))
 
     def test_exception_when_removing_particle_with_bad_id(self):
         with self.assertRaises(KeyError):
             self.pc.remove_particle(uuid.UUID(int=23325))
 
     def test_iter_particles_when_passing_ids(self):
-        particle_ids = [p.id for p in self.p_list[::2]]
+        particle_ids = [p.uid for p in self.p_list[::2]]
         iterated_ids = [
-            particle.id for particle in self.pc.iter_particles(particle_ids)]
+            particle.uid for particle in self.pc.iter_particles(particle_ids)]
         self.assertEqual(particle_ids, iterated_ids)
 
     def test_iter_all_particles(self):
-        particle_ids = [p.id for p in self.p_list]
+        particle_ids = [p.uid for p in self.p_list]
         iterated_ids = [
-            particle.id for particle in self.pc.iter_particles()]
+            particle.uid for particle in self.pc.iter_particles()]
         # The order of iteration is not important in this case.
         self.assertItemsEqual(particle_ids, iterated_ids)
 
     def test_exception_on_iter_particles_when_passing_wrong_ids(self):
-        ids = [particle.id for particle in self.p_list]
+        ids = [particle.uid for particle in self.p_list]
         ids.append(uuid.UUID(int=20))
         with self.assertRaises(KeyError):
             for particle in self.pc.iter_particles(ids):
-                last_id = particle.id
+                last_id = particle.uid
                 continue
-        self.assertEqual(last_id, self.p_list[-1].id)
+        self.assertEqual(last_id, self.p_list[-1].uid)
 
 
 class ParticleContainerAddBondsTestCase(unittest.TestCase):
@@ -155,15 +155,15 @@ class ParticleContainerAddBondsTestCase(unittest.TestCase):
         self.pc = ParticleContainer(name="foo")
 
     def test_has_bond(self):
-        id = self.pc.add_bond(self.b_list[0])
-        self.assertTrue(self.pc.has_bond(id))
+        uid = self.pc.add_bond(self.b_list[0])
+        self.assertTrue(self.pc.has_bond(uid))
         self.assertFalse(self.pc.has_bond(uuid.UUID(int=2122)))
 
     def test_add_bond(self):
         ids = [self.pc.add_bond(bond) for bond in self.b_list]
         for index, bond in enumerate(self.p_list):
             self.assertTrue(self.pc.has_bond(bond.id))
-            self.assertEqual(bond.id, ids[index])
+            self.assertEqual(bond.uid, ids[index])
 
     def test_exception_when_adding_bond_twice(self):
         for bond in self.b_list:
@@ -183,12 +183,12 @@ class ParticleContainerManipulatingBondsTestCase(unittest.TestCase):
             self.pc.add_bond(self.b_list[i])
 
     def test_update_bond(self):
-        bond = self.pc.get_bond(self.b_list[1].id)
+        bond = self.pc.get_bond(self.b_list[1].uid)
         bond.particles = bond.particles[:-1]
         self.pc.update_bond(bond)
-        new_bond = self.pc.get_bond(bond.id)
+        new_bond = self.pc.get_bond(bond.uid)
         self.assertTrue(new_bond is not bond)
-        self.assertEqual(bond.id, new_bond.id)
+        self.assertEqual(bond.uid, new_bond.uid)
         self.assertEqual(bond.particles, new_bond.particles)
         self.assertEqual(bond.data, bond.data)
 
@@ -199,33 +199,33 @@ class ParticleContainerManipulatingBondsTestCase(unittest.TestCase):
 
     def test_remove_bond(self):
         bond = self.b_list[0]
-        self.pc.remove_bond(bond.id)
-        self.assertFalse(self.pc.has_bond(bond.id))
+        self.pc.remove_bond(bond.uid)
+        self.assertFalse(self.pc.has_bond(bond.uid))
 
     def test_exception_removing_bond_with_missing_id(self):
         with self.assertRaises(KeyError):
             self.pc.remove_bond(uuid.UUID(int=12124124))
 
     def test_iter_bonds_when_passing_ids(self):
-        ids = [b.id for b in self.b_list[::2]]
+        ids = [b.uid for b in self.b_list[::2]]
         iterated_ids = [
-            bond.id for bond in self.pc.iter_bonds(ids)]
+            bond.uid for bond in self.pc.iter_bonds(ids)]
         self.assertEqual(ids, iterated_ids)
 
     def test_iter_all_bonds(self):
-        bonds_ids = [b.id for b in self.b_list]
-        iterated_ids = [bond.id for bond in self.pc.iter_bonds()]
+        bonds_ids = [b.uid for b in self.b_list]
+        iterated_ids = [bond.uid for bond in self.pc.iter_bonds()]
         # The order of iteration is not important in this case.
         self.assertItemsEqual(bonds_ids, iterated_ids)
 
     def test_exception_on_iter_bonds_when_passing_wrong_ids(self):
-        bonds_ids = [bond.id for bond in self.b_list]
+        bonds_ids = [bond.uid for bond in self.b_list]
         bonds_ids.append(uuid.UUID(int=20))
         with self.assertRaises(KeyError):
             for bond in self.pc.iter_bonds(bonds_ids):
-                last_id = bond.id
+                last_id = bond.uid
                 continue
-        self.assertEqual(last_id, self.b_list[-1].id)
+        self.assertEqual(last_id, self.b_list[-1].uid)
 
 
 if __name__ == '__main__':

--- a/simphony/io/file_particle_container.py
+++ b/simphony/io/file_particle_container.py
@@ -258,7 +258,7 @@ class FileParticleContainer(ABCParticleContainer):
     def _generate_unique_id(self, table, number_tries=1000):
         for n in xrange(number_tries):
             uid = random.randint(0, MAX_INT)
-            for _ in table.where('id == value', condvars={'value': uid}):
+            for _ in table.where('uid == value', condvars={'value': uid}):
                 break
             else:
                 return uid

--- a/simphony/io/file_particle_container.py
+++ b/simphony/io/file_particle_container.py
@@ -15,12 +15,12 @@ MAX_INT = numpy.iinfo(numpy.uint32).max
 
 
 class _ParticleDescription(tables.IsDescription):
-    id = tables.UInt32Col(pos=1)
+    uid = tables.UInt32Col(pos=1)
     coordinates = tables.Float64Col(pos=2, shape=(3,))
 
 
 class _BondDescription(tables.IsDescription):
-    id = tables.UInt32Col(pos=1)
+    uid = tables.UInt32Col(pos=1)
     # storing up to fixed number of particles for each bond
     particle_ids = tables.Int64Col(
         pos=2, shape=(MAX_NUMBER_PARTICLES_IN_BOND,))
@@ -70,23 +70,23 @@ class FileParticleContainer(ABCParticleContainer):
            if an id is given which already exists.
 
         """
-        id = particle.id
-        if id is None:
-            id = self._generate_unique_id(self._group.particles)
+        uid = particle.uid
+        if uid is None:
+            uid = self._generate_unique_id(self._group.particles)
         else:
             for _ in self._group.particles.where(
-                    'id == value', condvars={'value': id}):
+                    'uid == value', condvars={'value': uid}):
                 raise ValueError(
-                    'Particle (id={id}) already exists'.format(id=id))
+                    'Particle (id={id}) already exists'.format(uid=uid))
 
         # insert a new particle record
-        self._group.particles.append([(id, particle.coordinates)])
-        return id
+        self._group.particles.append([(uid, particle.coordinates)])
+        return uid
 
     def update_particle(self, particle):
         """Update particle"""
         for row in self._group.particles.where(
-                'id == value', condvars={'value': particle.id}):
+                'uid == value', condvars={'value': particle.uid}):
             row['coordinates'] = list(particle.coordinates)
             row.update()
             # see https://github.com/PyTables/PyTables/issues/11
@@ -94,22 +94,22 @@ class FileParticleContainer(ABCParticleContainer):
             return
         else:
             raise ValueError(
-                'Particle (id={id}) does not exist'.format(id=particle.id))
+                'Particle (id={id}) does not exist'.format(id=particle.uid))
 
-    def get_particle(self, id):
+    def get_particle(self, uid):
         """Get particle"""
         for row in self._group.particles.where(
-                'id == value', condvars={'value': id}):
+                'uid == value', condvars={'value': uid}):
             return Particle(
-                id=id, coordinates=tuple(row['coordinates']))
+                uid=uid, coordinates=tuple(row['coordinates']))
         else:
             raise ValueError(
-                'Particle (id={id}) does not exist'.format(id=id))
+                'Particle (id={id}) does not exist'.format(id=uid))
 
-    def remove_particle(self, id):
+    def remove_particle(self, uid):
         """Remove particle"""
         for row in self._group.particles.where(
-                'id == value', condvars={'value': id}):
+                'uid == value', condvars={'value': uid}):
             if self._group.particles.nrows == 1:
                 # pytables due to hdf5 limitations does
                 # not support removing the last row of table
@@ -122,14 +122,14 @@ class FileParticleContainer(ABCParticleContainer):
             return
         else:
             raise ValueError(
-                'Particle (id={id}) does not exist'.format(id=id))
+                'Particle (id={id}) does not exist'.format(id=uid))
 
     def iter_particles(self, ids=None):
         """Get iterator over particles"""
         if ids is None:
             for row in self._group.particles:
                 yield Particle(
-                    id=row['id'], coordinates=tuple(row['coordinates']))
+                    uid=row['uid'], coordinates=tuple(row['coordinates']))
         else:
             # FIXME: we might want to use an indexed query for these cases.
             for particle_id in ids:
@@ -155,47 +155,47 @@ class FileParticleContainer(ABCParticleContainer):
            if an id is given which already exists.
 
         """
-        id = bond.id
-        if id is None:
-            id = self._generate_unique_id(self._group.bonds)
+        uid = bond.uid
+        if uid is None:
+            uid = self._generate_unique_id(self._group.bonds)
         else:
             for r in self._group.bonds.where(
-                    'id == value', condvars={'value': id}):
+                    'uid == value', condvars={'value': uid}):
                 raise ValueError(
-                    'Bond (id={id}) already exists'.format(id=id))
+                    'Bond (id={id}) already exists'.format(id=uid))
 
         # insert a new bond record
-        self._group.bonds.append([self._bond_to_row(bond, id)])
-        return id
+        self._group.bonds.append([self._bond_to_row(bond, uid)])
+        return uid
 
     def update_bond(self, bond):
         """Update particle"""
         for row in self._group.bonds.where(
-                'id == value', condvars={'value': bond.id}):
+                'uid == value', condvars={'value': bond.uid}):
             _, row['particle_ids'], row['n_particle_ids'] = \
-                self._bond_to_row(bond, bond.id)
+                self._bond_to_row(bond, bond.uid)
             row.update()
             # see https://github.com/PyTables/PyTables/issues/11
             row._flush_mod_rows()
             return
         else:
             raise ValueError(
-                'Bond (id={id}) does not exist'.format(id=bond.id))
+                'Bond (id={id}) does not exist'.format(id=bond.uid))
 
-    def get_bond(self, id):
+    def get_bond(self, uid):
         """Get bond"""
         for row in self._group.bonds.where(
-                'id == value', condvars={'value': id}):
+                'uid == value', condvars={'value': uid}):
             particles = row['particle_ids'][:row['n_particle_ids']]
             # FIXME: do we have to convert to a tuple, why not a list?
-            return Bond(id=row['id'], particles=tuple(particles))
+            return Bond(uid=row['uid'], particles=tuple(particles))
         else:
-            raise ValueError('Bond (id={id}) does not exist'.format(id=id))
+            raise ValueError('Bond (id={id}) does not exist'.format(id=uid))
 
-    def remove_bond(self, id):
+    def remove_bond(self, uid):
         """Remove bond"""
         for row in self._group.bonds.where(
-                'id == value', condvars={'value': id}):
+                'uid == value', condvars={'value': uid}):
             if self._group.bonds.nrows == 1:
                 # pytables due to hdf5 limitations does
                 # not support removing the last row of table
@@ -216,22 +216,22 @@ class FileParticleContainer(ABCParticleContainer):
             for row in self._group.bonds:
                 n = row['n_particle_ids']
                 particles = row['particle_ids'][:n]
-                yield Bond(id=row['id'], particles=tuple(particles))
+                yield Bond(uid=row['uid'], particles=tuple(particles))
         else:
-            for id in ids:
-                yield self.get_bond(id)
+            for uid in ids:
+                yield self.get_bond(uid)
 
-    def has_particle(self, id):
+    def has_particle(self, uid):
         """Checks if a particle with id "id" exists in the container."""
         for row in self._group.particles.where(
-                'id == value', condvars={'value': id}):
+                'uid == value', condvars={'value': uid}):
             return True
         return False
 
-    def has_bond(self, id):
+    def has_bond(self, uid):
         """Checks if a bond with id "id" exists in the container."""
         for row in self._group.bonds.where(
-                'id == value', condvars={'value': id}):
+                'uid == value', condvars={'value': uid}):
             return True
         return False
 
@@ -245,7 +245,7 @@ class FileParticleContainer(ABCParticleContainer):
             self._file.create_table(
                 self._group, "bonds", _BondDescription)
 
-    def _bond_to_row(self, bond, id):
+    def _bond_to_row(self, bond, uid):
         n = len(bond.particles)
         if n > MAX_NUMBER_PARTICLES_IN_BOND:
             raise Exception(
@@ -253,14 +253,14 @@ class FileParticleContainer(ABCParticleContainer):
                     n=n, maxn=MAX_NUMBER_PARTICLES_IN_BOND))
         particle_ids = [0] * MAX_NUMBER_PARTICLES_IN_BOND
         particle_ids[:n] = bond.particles
-        return id, particle_ids, n
+        return uid, particle_ids, n
 
     def _generate_unique_id(self, table, number_tries=1000):
         for n in xrange(number_tries):
-            id = random.randint(0, MAX_INT)
-            for _ in table.where('id == value', condvars={'value': id}):
+            uid = random.randint(0, MAX_INT)
+            for _ in table.where('id == value', condvars={'value': uid}):
                 break
             else:
-                return id
+                return uid
         else:
             raise Exception('Id could not be generated')

--- a/simphony/io/tests/test_cuds_file.py
+++ b/simphony/io/tests/test_cuds_file.py
@@ -15,7 +15,7 @@ class TestCudsFile(unittest.TestCase):
         # create some particles
         self.particles = []
         for i in xrange(10):
-            self.particles.append(Particle((1.1*i, 2.2*i, 3.3*i), id=i))
+            self.particles.append(Particle((1.1*i, 2.2*i, 3.3*i), uid=i))
 
         self.file_a = CudsFile.open('test_A.cuds')
         self.file_b = CudsFile.open('test_B.cuds')
@@ -94,10 +94,10 @@ class TestCudsFile(unittest.TestCase):
         pc_test_a = self.file_a.add_particle_container(
             ParticleContainer(name="test"))
         for p in self.particles:
-            id = pc_test_a.add_particle(p)
-            self.assertEqual(p.id, id)
+            uid = pc_test_a.add_particle(p)
+            self.assertEqual(p.uid, uid)
             self.assertEqual(
-                p.coordinates, pc_test_a.get_particle(id).coordinates)
+                p.coordinates, pc_test_a.get_particle(uid).coordinates)
 
         num_particles = len(list(p for p in pc_test_a.iter_particles()))
         self.assertEqual(num_particles, len(self.particles))
@@ -107,24 +107,24 @@ class TestCudsFile(unittest.TestCase):
         pc_test_b = self.file_b.add_particle_container(pc_test_a)
 
         for p in pc_test_a.iter_particles():
-            p1 = pc_test_b.get_particle(p.id)
-            self.assertEqual(p1.id, p.id)
+            p1 = pc_test_b.get_particle(p.uid)
+            self.assertEqual(p1.uid, p.uid)
             self.assertEqual(p1.coordinates, p.coordinates)
 
         # close file and test if we can access it
         self.file_a.close()
         with self.assertRaises(Exception):
-            pc_test_a.delete(self.particles[0].id)
+            pc_test_a.delete(self.particles[0].uid)
         with self.assertRaises(Exception):
             pc_closed_file = self.file_a.get_particle_container('test')
-            pc_closed_file.delete(self.particles[0].id)
+            pc_closed_file.delete(self.particles[0].uid)
 
         # reopen file (in append mode)
         self.file_a = CudsFile.open('test_A.cuds')
         pc_test_a = self.file_a.get_particle_container('test')
         for p in self.particles:
-            p1 = pc_test_a.get_particle(p.id)
-            self.assertEqual(p1.id, p.id)
+            p1 = pc_test_a.get_particle(p.uid)
+            self.assertEqual(p1.uid, p.uid)
             self.assertEqual(p1.coordinates, p.coordinates)
 
     def test_iter_particle_container(self):

--- a/simphony/io/tests/test_file_particle_container.py
+++ b/simphony/io/tests/test_file_particle_container.py
@@ -12,9 +12,9 @@ def _convert_to_tuple_list(particle_or_bond_list):
     converted = []
     for item in particle_or_bond_list:
         if isinstance(item, Particle):
-            converted.append((item.id, item.coordinates))
+            converted.append((item.uid, item.coordinates))
         elif isinstance(item, Bond):
-            converted.append((item.id, item.particles))
+            converted.append((item.uid, item.particles))
         else:
             raise Exception('unexpected type: %s' % type(item))
     return converted
@@ -35,12 +35,12 @@ class TestFileParticleContainer(unittest.TestCase):
             ParticleContainer(name="test"))
 
         # create two particles (with unique ids)
-        self.particle_1 = Particle((0.1, 0.4, 5.0), id=0)
-        self.particle_2 = Particle((0.2, 0.45, 50.0), id=1)
+        self.particle_1 = Particle((0.1, 0.4, 5.0), uid=0)
+        self.particle_2 = Particle((0.2, 0.45, 50.0), uid=1)
 
         # create two bonds (with unique ids)
-        self.bond_1 = Bond((1, 0), id=0)
-        self.bond_2 = Bond((0, 1), id=1)
+        self.bond_1 = Bond((1, 0), uid=0)
+        self.bond_2 = Bond((0, 1), uid=1)
 
     def tearDown(self):
         if os.path.exists(self.filename):
@@ -62,9 +62,9 @@ class TestFileParticleContainer(unittest.TestCase):
 
     def test_add_get_particle(self):
         self.pc.add_particle(self.particle_1)
-        particles = self.pc.get_particle(self.particle_1.id)
+        particles = self.pc.get_particle(self.particle_1.uid)
         self.assertTrue(particles is not self.particle_1)
-        self.assertEqual(particles.id, self.particle_1.id)
+        self.assertEqual(particles.uid, self.particle_1.uid)
         self.assertEqual(particles.coordinates, self.particle_1.coordinates)
 
     def test_add_particle_with_same_id(self):
@@ -74,17 +74,17 @@ class TestFileParticleContainer(unittest.TestCase):
 
     def test_has_particle_ok(self):
         self.pc.add_particle(self.particle_1)
-        self.assertTrue(self.pc.has_particle(self.particle_1.id))
+        self.assertTrue(self.pc.has_particle(self.particle_1.uid))
 
     def test_has_particle_false(self):
         self.assertFalse(self.pc.has_particle(self.particle_1))
 
     def test_add_get_particle_with_default_id(self):
         p = Particle((1.0, 1.0, 0.0))
-        id = self.pc.add_particle(p)
-        particle = self.pc.get_particle(id)
+        uid = self.pc.add_particle(p)
+        particle = self.pc.get_particle(uid)
         self.assertTrue(particle is not p)
-        self.assertEqual(particle.id, id)
+        self.assertEqual(particle.uid, uid)
         self.assertEqual(particle.coordinates, p.coordinates)
 
     def test_get_particle_throws(self):
@@ -100,7 +100,7 @@ class TestFileParticleContainer(unittest.TestCase):
         p = copy.deepcopy(self.particle_1)
         p.coordinates = (42, 42, 42)
         self.pc.update_particle(p)
-        updated_p = self.pc.get_particle(p.id)
+        updated_p = self.pc.get_particle(p.uid)
 
         self.assertEqual(p, updated_p)
         self.assertNotEqual(p, self.particle_1)
@@ -112,17 +112,17 @@ class TestFileParticleContainer(unittest.TestCase):
         particles = []
         for i in xrange(10):
             particles.append(Particle(
-                id=i, coordinates=(0.0, 0.0, 0.0)))
+                uid=i, coordinates=(0.0, 0.0, 0.0)))
 
         for p in particles:
             self.pc.add_particle(p)
 
         for p in particles:
-            self.pc.remove_particle(p.id)
+            self.pc.remove_particle(p.uid)
 
         for p in particles:
             with self.assertRaises(ValueError):
-                self.pc.get_particle(p.id)
+                self.pc.get_particle(p.uid)
 
         current = [p for p in self.pc.iter_particles()]
         self.assertFalse(current)
@@ -138,28 +138,28 @@ class TestFileParticleContainer(unittest.TestCase):
 
         # test iterating particles by giving ids
         particles1 = [self.particle_1, self.particle_2]
-        ids1 = list(p.id for p in particles1)
+        ids1 = list(p.uid for p in particles1)
         particles2 = list(p for p in self.pc.iter_particles(ids1))
         self.compare_list(particles1, particles2)
 
         # test again with different order of ids
         particles1 = [self.particle_2, self.particle_1, self.particle_1]
-        ids1 = list(p.id for p in particles1)
+        ids1 = list(p.uid for p in particles1)
         particles2 = list(p for p in self.pc.iter_particles(ids1))
         self.compare_list(particles1, particles2, order_sensitive=False)
 
     def test_add_get_bond(self):
         self.pc.add_bond(self.bond_1)
-        bond = self.pc.get_bond(self.bond_1.id)
+        bond = self.pc.get_bond(self.bond_1.uid)
         self.assertTrue(bond is not self.bond_1)
         self.assertEqual(bond, self.bond_1)
 
     def test_add_get_bond_with_default_id(self):
         b = Bond((1, 0))
-        id = self.pc.add_bond(b)
-        bond = self.pc.get_bond(id)
+        uid = self.pc.add_bond(b)
+        bond = self.pc.get_bond(uid)
         self.assertTrue(bond is not b)
-        self.assertEqual(bond.id, id)
+        self.assertEqual(bond.uid, uid)
         self.assertEqual(bond.particles, b.particles)
 
     def test_add_bond_with_same_id(self):
@@ -169,7 +169,7 @@ class TestFileParticleContainer(unittest.TestCase):
 
     def test_has_bond_ok(self):
         self.pc.add_bond(self.bond_1)
-        self.assertTrue(self.pc.has_bond(self.bond_1.id))
+        self.assertTrue(self.pc.has_bond(self.bond_1.uid))
 
     def test_has_bond_false(self):
         self.assertFalse(self.pc.has_bond(self.bond_1))
@@ -187,7 +187,7 @@ class TestFileParticleContainer(unittest.TestCase):
         b = copy.deepcopy(self.bond_1)
         b.particles = (1, 1)
         self.pc.update_bond(b)
-        updated_b = self.pc.get_bond(b.id)
+        updated_b = self.pc.get_bond(b.uid)
 
         self.assertEqual(b, updated_b)
         self.assertNotEqual(b, self.bond_1)
@@ -198,17 +198,17 @@ class TestFileParticleContainer(unittest.TestCase):
 
         bonds = []
         for i in xrange(10):
-            bonds.append(Bond(id=i, particles=(0, 0)))
+            bonds.append(Bond(uid=i, particles=(0, 0)))
 
         for bond in bonds:
             self.pc.add_bond(bond)
 
         for bond in bonds:
-            self.pc.remove_bond(bond.id)
+            self.pc.remove_bond(bond.uid)
 
         for bond in bonds:
             with self.assertRaises(ValueError):
-                self.pc.get_bond(bond.id)
+                self.pc.get_bond(bond.uid)
 
     def test_iter_bonds(self):
         bondsA = [self.bond_1, self.bond_2]
@@ -221,16 +221,16 @@ class TestFileParticleContainer(unittest.TestCase):
 
         # test iterating bonds by giving ids
         bondsA = [self.bond_1, self.bond_2]
-        ids1 = list(p.id for p in bondsA)
+        ids1 = list(p.uid for p in bondsA)
         bondsB = list(p for p in self.pc.iter_bonds(ids1))
         self.compare_list(bondsA, bondsB)
 
     def assertParticleEqual(self, a, b, msg=None):
-        self.assertEqual(a.id, b.id)
+        self.assertEqual(a.uid, b.uid)
         self.assertEqual(a.coordinates, b.coordinates)
 
     def assertBondEqual(self, a, b, msg=None):
-        self.assertEqual(a.id, b.id)
+        self.assertEqual(a.uid, b.uid)
         self.assertEqual(a.particles, b.particles)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates the abstract description and native implementation of the Particles and Mesh containers to use `uid` instead of `id` or `uuid`