### PR TITLE
Feature mesh data property

### DIFF
--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -237,7 +237,7 @@ class Mesh(ABCMesh):
                 + "DataContainer expected."
             raise TypeError(error_str)
         self._data = value
-    
+
     def get_point(self, uuid):
         """ Returns a point with a given uuid.
 

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -228,11 +228,11 @@ class Mesh(ABCMesh):
 
     @property
     def data(self):
-        return self._data
+        return dc.DataContainer(self._data)
 
     @data.setter
     def data(self, value):
-        self._data = value
+        self._data = dc.DataContainer(value)
 
     def get_point(self, uuid):
         """ Returns a point with a given uuid.

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -218,13 +218,22 @@ class Mesh(ABCMesh):
 
     def __init__(self, name):
         self.name = name
-        self.data = 0
 
         self._points = {}
         self._edges = {}
         self._faces = {}
         self._cells = {}
 
+        self._data = dc.DataContainer()
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data = value
+    
     def get_point(self, uuid):
         """ Returns a point with a given uuid.
 

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -232,6 +232,10 @@ class Mesh(ABCMesh):
 
     @data.setter
     def data(self, value):
+        if not isinstance(value, dc.DataContainer):
+            error_str = "Trying to update an object with the wrong type. "\
+                + "DataContainer expected."
+            raise TypeError(error_str)
         self._data = value
     
     def get_point(self, uuid):

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -232,10 +232,6 @@ class Mesh(ABCMesh):
 
     @data.setter
     def data(self, value):
-        if not isinstance(value, dc.DataContainer):
-            error_str = "Trying to update an object with the wrong type. "\
-                + "DataContainer expected."
-            raise TypeError(error_str)
         self._data = value
 
     def get_point(self, uuid):

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -7,6 +7,10 @@ mesh module functionalities
 
 import unittest
 
+from functools import partial
+
+from simphony.testing.utils import compare_data_containers
+
 from simphony.cuds.mesh import Mesh
 from simphony.cuds.mesh import Point
 from simphony.cuds.mesh import Edge
@@ -26,6 +30,9 @@ class TestSequenceFunctions(unittest.TestCase):
         to tests all the mesh methods
 
         """
+        self.addTypeEqualityFunc(
+            DataContainer, partial(compare_data_containers, testcase=self))
+
         self.mesh = Mesh(name="foo")
         self.points = [
             Point((0.0, 0.0, 0.0)),
@@ -694,7 +701,8 @@ class TestSequenceFunctions(unittest.TestCase):
         self.mesh.data = org_data
         ret_data = self.mesh.data
 
-        self.assertItemsEqual(org_data, ret_data)
+        self.assertEqual(org_data, ret_data)
+        self.assertIsNot(org_data, ret_data)
 
     def test_modify_data(self):
         """ Check that data is consistent
@@ -711,11 +719,12 @@ class TestSequenceFunctions(unittest.TestCase):
         self.mesh.data = org_data
         mod_data = self.mesh.data
 
-        mod_data[CUBA.VELOCITY] = (0, 0, 0)
+        mod_data[CUBA.VELOCITY] = (1, 1, 1)
 
         ret_data = self.mesh.data
 
-        self.assertItemsEqual(org_data, ret_data)
+        self.assertEqual(org_data, ret_data)
+        self.assertIsNot(org_data, ret_data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -691,7 +691,7 @@ class TestSequenceFunctions(unittest.TestCase):
         self.mesh.data = org_data
         ret_data = self.mesh.data
 
-        self.assertItemsEqual(org_data,ret_data)
+        self.assertItemsEqual(org_data, ret_data)
 
     def test_modify_data(self):
 
@@ -706,11 +706,10 @@ class TestSequenceFunctions(unittest.TestCase):
 
         ret_data = self.mesh.data
 
-        self.assertItemsEqual(org_data,ret_data)
+        self.assertItemsEqual(org_data, ret_data)
 
     def test_modify_data_incorrect_type(self):
 
-        org_data = "I'm not a DataContainer"
         with self.assertRaises(TypeError):
             self.mesh.data = "I'm not a DataContainer"
 

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -683,6 +683,9 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertItemsEqual(cell_upd.points, cell_ret.points)
 
     def test_set_data(self):
+        """ Check that data can be retrieved
+
+        """
 
         org_data = DataContainer()
 
@@ -694,6 +697,12 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertItemsEqual(org_data, ret_data)
 
     def test_modify_data(self):
+        """ Check that data is consistent
+
+        Check that the internal data of the mesh cannot be modified
+        outise the mesh class
+
+        """
 
         org_data = DataContainer()
 
@@ -709,6 +718,9 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertItemsEqual(org_data, ret_data)
 
     def test_modify_data_incorrect_type(self):
+        """ Check that only a DataContainer can be assigned to mesh data
+
+        """
 
         with self.assertRaises(TypeError):
             self.mesh.data = "I'm not a DataContainer"

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -717,13 +717,5 @@ class TestSequenceFunctions(unittest.TestCase):
 
         self.assertItemsEqual(org_data, ret_data)
 
-    def test_modify_data_incorrect_type(self):
-        """ Check that only a DataContainer can be assigned to mesh data
-
-        """
-
-        with self.assertRaises(TypeError):
-            self.mesh.data = "I'm not a DataContainer"
-
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -6,13 +6,19 @@ mesh module functionalities
 """
 
 import unittest
+
+from functools import partial
+
+from simphony.testing.utils import compare_data_containers
+
 from simphony.cuds.mesh import Mesh
 from simphony.cuds.mesh import Point
 from simphony.cuds.mesh import Edge
 from simphony.cuds.mesh import Face
 from simphony.cuds.mesh import Cell
-# import simphony.core.data_container as dc
-# from simphony.core.cuba import CUBA
+
+from simphony.core.cuba import CUBA
+from simphony.core.data_container import DataContainer
 
 
 class TestSequenceFunctions(unittest.TestCase):
@@ -679,6 +685,17 @@ class TestSequenceFunctions(unittest.TestCase):
         cell_upd = self.mesh.get_cell(cuuids[0])
 
         self.assertItemsEqual(cell_upd.points, cell_ret.points)
+
+    def test_set_data(self):
+
+        org_data = DataContainer()
+
+        org_data[CUBA.VELOCITY] = (0, 0, 0)
+
+        self.mesh.data = org_data
+        ret_data = self.mesh.data
+
+        self.assertItemsEqual(org_data,ret_data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -697,5 +697,26 @@ class TestSequenceFunctions(unittest.TestCase):
 
         self.assertItemsEqual(org_data,ret_data)
 
+    def test_modify_data(self):
+
+        org_data = DataContainer()
+
+        org_data[CUBA.VELOCITY] = (0, 0, 0)
+
+        self.mesh.data = org_data
+        mod_data = self.mesh.data
+
+        mod_data[CUBA.VELOCITY] = (0, 0, 0)
+
+        ret_data = self.mesh.data
+
+        self.assertItemsEqual(org_data,ret_data)
+
+    def test_modify_data_incorrect_type(self):
+
+        org_data = "I'm not a DataContainer"
+        with self.assertRaises(TypeError):
+            self.mesh.data = "I'm not a DataContainer"
+
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/cuds/tests/test_mesh.py
+++ b/simphony/cuds/tests/test_mesh.py
@@ -7,10 +7,6 @@ mesh module functionalities
 
 import unittest
 
-from functools import partial
-
-from simphony.testing.utils import compare_data_containers
-
 from simphony.cuds.mesh import Mesh
 from simphony.cuds.mesh import Point
 from simphony.cuds.mesh import Edge


### PR DESCRIPTION
This should add the data property to the mesh class.

I agree with https://github.com/simphony/simphony-common/issues/84#issuecomment-78071986 data() and set_data(), but I understand that there is not yet a decision so I used a property instead.  

@itziakos , @nathanfranklin, @mehdisadeghi  Is this correct to fix https://github.com/simphony/simphony-common/issues/83 ?