### PR TITLE
PR: NotImplementedError for get_coordinate on Hexagonal lattices.

### DIFF
--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -112,6 +112,10 @@ class Lattice(ABCLattice):
         D x float
 
         """
+        if self._type == 'Hexagonal':
+            raise NotImplementedError("""Get_coordinate for
+                Hexagonal system not implemented!""")
+
         return self.origin + self.base_vect*np.array(index)
 
     @property

--- a/simphony/io/file_lattice.py
+++ b/simphony/io/file_lattice.py
@@ -139,6 +139,10 @@ class FileLattice(ABCLattice):
         D x float
 
         """
+        if self._type == 'Hexagonal':
+            raise NotImplementedError("""Get_coordinate for
+                Hexagonal system not implemented!""")
+
         return self._origin + self._base_vect*np.array(index)
 
     @property

--- a/simphony/io/tests/test_file_lattice.py
+++ b/simphony/io/tests/test_file_lattice.py
@@ -187,9 +187,5 @@ class TestFileLattice(unittest.TestCase):
         assert_array_equal(self.orthofilelat.get_coordinate((1, 1, 1)),
                            numpy.array((1.0, 2.0, 3.0)))
 
-        assert_array_equal(self.hexafilelat.get_coordinate((1, 1)),
-                           numpy.array((0.5, numpy.sqrt(3)/2)))
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before proper fixing of the problem, added a NotImplementedError when querying coordinates of a Hexagonal lattice nodes.