### PR TITLE
PR: High level data for H5Lattice

### DIFF
--- a/simphony/cuds/abstractlattice.py
+++ b/simphony/cuds/abstractlattice.py
@@ -16,6 +16,8 @@ class ABCLattice(object):
         lattice dimensions
     origin : D x float
         lattice origin
+    data : DataContainer
+        high level CUBA data assigned to lattice
 
     """
     __metaclass__ = ABCMeta
@@ -26,7 +28,7 @@ class ABCLattice(object):
 
         Parameters
         ----------
-        index: tuple of D x int
+        index : tuple of D x int
             node index coordinate
 
         Returns

--- a/simphony/io/h5_cuds.py
+++ b/simphony/io/h5_cuds.py
@@ -169,7 +169,7 @@ class H5CUDS(object):
             h5lat.update_node(node)
 
         # Copy lattice high level data to the file
-        h5lat.data = {k: lattice.data[k] for k in lattice.data}
+        h5lat.data = lattice.data
         self._handle.flush()
 
         return h5lat

--- a/simphony/io/h5_cuds.py
+++ b/simphony/io/h5_cuds.py
@@ -168,6 +168,8 @@ class H5CUDS(object):
         for node in lattice.iter_nodes():
             h5lat.update_node(node)
 
+        # Copy lattice high level data to the file
+        h5lat.data = {k: lattice.data[k] for k in lattice.data}
         self._handle.flush()
 
         return h5lat

--- a/simphony/io/h5_cuds.py
+++ b/simphony/io/h5_cuds.py
@@ -158,9 +158,10 @@ class H5CUDS(object):
             raise ValueError(
                 'Lattice \'{n}\` already exists'.format(n=lattice.name))
 
-        # Create a h5lattice with all CUBA-keys defined
-        h5lat = H5Lattice.create_new(self._root.lattice, lattice.name,
-                                     lattice.type, lattice.base_vect,
+        group = self._handle.create_group('/lattice/', lattice.name)
+
+        # Create a h5_lattice with all CUBA-keys defined
+        h5lat = H5Lattice.create_new(group, lattice.type, lattice.base_vect,
                                      lattice.size, lattice.origin)
 
         # Copy the contents of the lattice to the file
@@ -224,10 +225,11 @@ class H5CUDS(object):
         name : str
             name of lattice to return
         """
-        if name in self._root.lattice:
-            lat = H5Lattice(self._root.lattice, name)
-            return lat
-        else:
+        try:
+            group = self._root.lattice._f_get_child(name)
+            h5lat = H5Lattice(group)
+            return h5lat
+        except tables.NoSuchNodeError:
             raise ValueError(
                 'Lattice \'{n}\` does not exist'.format(n=name))
 
@@ -328,7 +330,7 @@ class H5CUDS(object):
         """
         if names is None:
             for lattice in self._root.lattice._f_iter_nodes():
-                yield self.get_lattice(lattice.name)
+                yield self.get_lattice(lattice._v_name)
         else:
             for name in names:
                 yield self.get_lattice(name)

--- a/simphony/io/tests/test_h5_cuds.py
+++ b/simphony/io/tests/test_h5_cuds.py
@@ -398,6 +398,8 @@ class TestH5CUDS(unittest.TestCase):
         lat = Lattice('test_lattice', 'cubic', (1.0, 1.0, 1.0),
                       (2, 3, 4), (0.0, 0.0, 0.0))
 
+        lat.data = {CUBA.VELOCITY: (1.0, -1.0, 0.0), CUBA.DENSITY: 9231}
+
         filename = os.path.join(self.temp_dir, 'test.cuds')
         with closing(H5CUDS.open(filename, 'w')) as handle:
             handle.add_lattice(lat)
@@ -408,6 +410,9 @@ class TestH5CUDS(unittest.TestCase):
                 M = lat.get_node(N.index)
                 self.assertEqual(N.index, M.index)
                 compare_data_containers(N.data, M.data, testcase=self)
+
+            # Compare high level data of lattices
+            compare_data_containers(lat.data, lat2.data, testcase=self)
 
             handle.delete_lattice('test_lattice')
             numlat = 0

--- a/simphony/io/tests/test_h5_lattice.py
+++ b/simphony/io/tests/test_h5_lattice.py
@@ -8,6 +8,7 @@ from simphony.io.h5_lattice import H5Lattice
 from numpy.testing import assert_array_equal
 from simphony.core.cuba import CUBA
 from simphony.testing.abc_check_lattice import ABCCheckLattice
+from simphony.core.data_container import DataContainer
 
 
 class CustomRecord(tables.IsDescription):
@@ -38,8 +39,10 @@ class TestH5Lattice(ABCCheckLattice, unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def container_factory(self, name, type_, base_vect, size, origin):
+        self.group = self.handle.create_group(
+            self.handle.root, name)
         return H5Lattice.create_new(
-            self.handle.root, name, type_, base_vect, size, origin)
+            self.group, type_, base_vect, size, origin)
 
     def supported_cuba(self):
         return set(CUBA)
@@ -48,12 +51,44 @@ class TestH5Lattice(ABCCheckLattice, unittest.TestCase):
         """ Checks that H5Lattice constructed from Lattice with a
         CustomRecord column description has correct attributes
         """
-        lattice = H5Lattice(self.handle.root, 'foo')
+        lattice = H5Lattice(self.group)
         self.assertEqual(lattice.name, 'foo')
         self.assertEqual(lattice.type, 'Cubic')
         assert_array_equal(lattice.base_vect, self.base_vect)
         self.assertItemsEqual(lattice.size, self.size)
         assert_array_equal(lattice.origin, self.origin)
+
+    def test_set_modify_data(self):
+        """ Check that data can be retrieved and is consistent. Check that
+        the internal data of the lattice cannot be modified outside the
+        lattice class
+        """
+        lattice = self.container_factory('test_lat', 'Cubic',
+                                         (1.0, 1.0, 1.0), (4, 3, 2),
+                                         (0, 0, 0))
+        org_data = DataContainer()
+
+        org_data[CUBA.VELOCITY] = (0, 0, 0)
+
+        lattice.data = org_data
+        ret_data = lattice.data
+
+        self.assertEqual(org_data, ret_data)
+        self.assertIsNot(org_data, ret_data)
+
+        org_data = DataContainer()
+
+        org_data[CUBA.VELOCITY] = (0, 0, 0)
+
+        lattice.data = org_data
+        mod_data = lattice.data
+
+        mod_data[CUBA.VELOCITY] = (1, 1, 1)
+
+        ret_data = lattice.data
+
+        self.assertEqual(org_data, ret_data)
+        self.assertIsNot(org_data, ret_data)
 
 
 class TestFileLatticeCustom(ABCCheckLattice, unittest.TestCase):
@@ -73,9 +108,10 @@ class TestFileLatticeCustom(ABCCheckLattice, unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def container_factory(self, name, type_, base_vect, size, origin):
-        return H5Lattice.create_new(
-            self.handle.root, 'foo', type_, base_vect,
-            size, origin, record=CustomRecord)
+        self.group = self.handle.create_group(
+            self.handle.root, name)
+        return H5Lattice.create_new(self.group, type_, base_vect, size,
+                                    origin, record=CustomRecord)
 
     def supported_cuba(self):
         return [CUBA.VELOCITY, CUBA.MATERIAL_ID, CUBA.DENSITY]
@@ -84,7 +120,7 @@ class TestFileLatticeCustom(ABCCheckLattice, unittest.TestCase):
         """ Checks that H5Lattice constructed from Lattice with a
         CustomRecord column description has correct attributes
         """
-        lattice = H5Lattice(self.handle.root, 'foo')
+        lattice = H5Lattice(self.group)
         self.assertEqual(lattice.name, 'foo')
         self.assertEqual(lattice.type, 'Cubic')
         assert_array_equal(lattice.base_vect, self.base_vect)


### PR DESCRIPTION
This commit fixes issue #15 for H5Lattice:
* High level CUDS data is now saved in a separate table named 'data'
* All Lattice related data (i.e. two separate tables) is now located in subgroup under /root/lattice/
* This implementation still uses PyTables attributes to store actual lattice metadata (size, etc.) instead of the new data-table