### PR TITLE
update docstrings of CUDS items iterators to reflect expected order of items

### DIFF
--- a/simphony/cuds/abstractlattice.py
+++ b/simphony/cuds/abstractlattice.py
@@ -54,7 +54,10 @@ class ABCLattice(object):
         Parameters
         ----------
         indices : iterable set of D x int, optional
-            node index coordinates
+            When indices (i.e. node index coordinates) are provided, then nodes
+            are returned in the same order of the provided indices. If indices
+            is None, there is no restriction on the order the nodes that are
+            are returned.
 
         Returns
         -------

--- a/simphony/cuds/abstractmesh.py
+++ b/simphony/cuds/abstractmesh.py
@@ -62,19 +62,19 @@ class ABCMesh(object):
         pass
 
     @abstractmethod
-    def iter_points(self, point_uids=None):
+    def iter_points(self, uids=None):
         pass
 
     @abstractmethod
-    def iter_edges(self, edge_uids=None):
+    def iter_edges(self, uids=None):
         pass
 
     @abstractmethod
-    def iter_faces(self, face_uids=None):
+    def iter_faces(self, uids=None):
         pass
 
     @abstractmethod
-    def iter_cells(self, cell_uids=None):
+    def iter_cells(self, uids=None):
         pass
 
     @abstractmethod

--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -89,7 +89,10 @@ class Lattice(ABCLattice):
         Parameters
         ----------
         indices : iterable set of D x int, optional
-            node index coordinates
+            When indices (i.e. node index coordinates) are provided, then nodes
+            are returned in the same order of the provided indices. If indices
+            is None, there is no restriction on the order the nodes that are
+            are returned.
 
         Returns
         -------

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -618,47 +618,41 @@ class Mesh(ABCMesh):
         cell_to_update.data = cell.data
         cell_to_update.points = cell.points
 
-    def iter_points(self, point_uids=None):
-        """ Returns an iterator over the selected points.
-
-        Returns an iterator over the points with uid in
-        point_uids. If none of the ids in point_uids exists,
-        an empty iterator is returned. If there is no ids
-        inside point_uids, a iterator over all points of
-        the mesh is returned instead.
+    def iter_points(self, uids=None):
+        """ Returns an iterator over points.
 
         Parameters
         ----------
-        point_uids : list of uid, optional
-            uids of the desired points, default empty
+        uids : iterable of uuid.UUID or None
+            When the uids are provided, then the points are returned in
+            the same order the uids are returned by the iterable. If uids is
+            None, then all points are returned by the interable and there
+            is no restriction on the order that they are returned.
 
         Returns
         -------
         iter
-            Iterator over the selected points
+            Iterator over the points
 
         """
 
-        if point_uids is None:
+        if uids is None:
             for point in self._points.values():
                 yield Point.from_point(point)
         else:
-            for point_uid in point_uids:
+            for point_uid in uids:
                 yield Point.from_point(self._points[point_uid])
 
-    def iter_edges(self, edge_uids=None):
-        """ Returns an iterator over the selected edges.
-
-        Returns an iterator over the edged with uid in
-        edge_uid. If none of the uids in edge_uids exists,
-        an empty iterator is returned. If there is no uids
-        inside edge_uids, a iterator over all edges of
-        the mesh is returned instead.
+    def iter_edges(self, uids=None):
+        """ Returns an iterator over edges.
 
         Parameters
         ----------
-        edge_uids : list of uid, optional
-            uids of the desired edges, default empty
+        uids : iterable of uuid.UUID  or None
+            When the uids are provided, then the edges are returned in the
+            same order the uids are returned by the iterable. If uids is None,
+            then all edges are returned by the interable and there is no
+            restriction on the order that they are returned.
 
         Returns
         -------
@@ -667,54 +661,48 @@ class Mesh(ABCMesh):
 
         """
 
-        if edge_uids is None:
+        if uids is None:
             for edge in self._edges.values():
                 yield Edge.from_edge(edge)
         else:
-            for edge_uid in edge_uids:
-                yield Edge.from_edge(self._edges[edge_uid])
+            for uid in uids:
+                yield Edge.from_edge(self._edges[uid])
 
-    def iter_faces(self, face_uids=None):
-        """ Returns an iterator over the selected faces.
-
-        Returns an iterator over the faces with uid in
-        face_uids. If none of the uuids in face_uids exists,
-        an empty iterator is returned. If there is no uids
-        inside face_uids, a iterator over all faces of
-        the mesh is returned instead.
+    def iter_faces(self, uids=None):
+        """ Returns an iterator over faces.
 
         Parameters
         ----------
-        face_uids : list of uid, optional
-            uids of the desired faces, default empty
+        uids : iterable of uuid.UUID  or None
+            When the uids are provided, then the faces are returned in the
+            same order the uids are returned by the iterable. If uids is None,
+            then all faces are returned by the interable and there is no
+            restriction on the order that they are returned.
 
         Returns
         -------
         iter
-            Iterator over the selected faces
+            Iterator over the faces
 
         """
 
-        if face_uids is None:
+        if uids is None:
             for face in self._faces.values():
                 yield Face.from_face(face)
         else:
-            for face_uid in face_uids:
-                yield Face.from_face(self._faces[face_uid])
+            for uid in uids:
+                yield Face.from_face(self._faces[uid])
 
-    def iter_cells(self, cell_uids=None):
-        """ Returns an iterator over the selected cells.
-
-        Returns an iterator over the cells with uid in
-        cell_uids. If none of the uids in cell_uids exists,
-        an empty iterator is returned. If there is no uuids
-        inside cell_uuids, a iterator over all cells of
-        the mesh is returned instead.
+    def iter_cells(self, uids=None):
+        """ Returns an iterator over cells.
 
         Parameters
         ----------
-        cell_uids : list of uid, optional
-            uids of the desired cell, default empty
+        uids : iterable of uuid.UUID  or None
+            When the uids are provided, then the cells are returned in the same
+            order the uids are returned by the iterable. If uids is None, then
+            all cells are returned by the interable and there is no restriction
+            on the order that they are returned.
 
         Returns
         -------
@@ -723,12 +711,12 @@ class Mesh(ABCMesh):
 
         """
 
-        if cell_uids is None:
+        if uids is None:
             for cell in self._cells.values():
                 yield Cell.from_cell(cell)
         else:
-            for cell_uid in cell_uids:
-                yield Cell.from_cell(self._cells[cell_uid])
+            for uid in uids:
+                yield Cell.from_cell(self._cells[uid])
 
     def has_edges(self):
         """ Check if the mesh has edges

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -12,7 +12,7 @@ import simphony.core.data_container as dc
 class Point(object):
     """ Coordinates describing a point in the space
 
-    Set of coordinates(x,y,z) describing a point in
+    Set of coordinates (x,y,z) describing a point in
     the space and data about that point
 
     Parameters
@@ -171,7 +171,7 @@ class Mesh(ABCMesh):
     methods to interact with them. The methods are
     divided in four different blocks:
 
-    (1) methods to get the related item with the provided uuid;
+    (1) methods to get the related item with the provided uid;
     (2) methods to add a new item or replace;
     (3) generator methods that return iterators
         over all or some of the mesh items and;
@@ -227,10 +227,10 @@ class Mesh(ABCMesh):
         self._data = dc.DataContainer(value)
 
     def get_point(self, uid):
-        """ Returns a point with a given uuid.
+        """ Returns a point with a given uid.
 
         Returns the point stored in the mesh
-        identified by uuid. If such point do not
+        identified by uid. If such point do not
         exists an exception is raised.
 
         Parameters
@@ -241,26 +241,26 @@ class Mesh(ABCMesh):
         Returns
         -------
         Point
-            Mesh point identified by uuid
+            Mesh point identified by uid
 
         Raises
         ------
-        Exception
-            If the point identified by uuid was not found
+        KeyError
+            If the point identified by uid was not found
 
         """
 
         try:
             return Point.from_point(self._points[uid])
         except KeyError:
-            error_str = "Trying to get an non-existing point with uuid: {}"
+            error_str = "Trying to get an non-existing point with uid: {}"
             raise ValueError(error_str.format(uid))
 
     def get_edge(self, uid):
-        """ Returns an edge with a given uuid.
+        """ Returns an edge with a given uid.
 
         Returns the edge stored in the mesh
-        identified by uuid. If such edge do not
+        identified by uid. If such edge do not
         exists an exception is raised.
 
         Parameters
@@ -275,8 +275,8 @@ class Mesh(ABCMesh):
 
         Raises
         ------
-        Exception
-            If the edge identified by uuid was not found
+        KeyError
+            If the edge identified by uid was not found
 
         """
 
@@ -290,8 +290,8 @@ class Mesh(ABCMesh):
         """ Returns a face with a given uid.
 
         Returns the face stored in the mesh
-        identified by uid. If such face do not
-        exists an exception is raised.
+        identified by uid. If such a face does
+        not exists an exception is raised.
 
         Parameters
         ----------
@@ -305,8 +305,8 @@ class Mesh(ABCMesh):
 
         Raises
         ------
-        Exception
-            If the face identified by uuid was not found
+        KeyError
+            If the face identified by uid was not found
 
         """
 
@@ -320,7 +320,7 @@ class Mesh(ABCMesh):
         """ Returns a cell with a given uid.
 
         Returns the cell stored in the mesh
-        identified by uuid . If such cell do not
+        identified by uid. If such a cell does not
         exists an exception is raised.
 
         Parameters
@@ -335,8 +335,8 @@ class Mesh(ABCMesh):
 
         Raises
         ------
-        Exception
-            If the cell identified by uuid was not found
+        KeyError
+            If the cell identified by uid was not found
 
         """
 
@@ -369,7 +369,7 @@ class Mesh(ABCMesh):
             point.uid = self._generate_uuid()
 
         if point.uid in self._points:
-            error_str = "Trying to add an already existing point with uuid: "\
+            error_str = "Trying to add an already existing point with uid: "\
                 + str(point.uid)
             raise KeyError(error_str)
 
@@ -400,7 +400,7 @@ class Mesh(ABCMesh):
             edge.uid = self._generate_uuid()
 
         if edge.uid in self._edges:
-            error_str = "Trying to add an already existing edge with uuid: "\
+            error_str = "Trying to add an already existing edge with uid: "\
                 + str(edge.uid)
             raise KeyError(error_str)
 
@@ -431,7 +431,7 @@ class Mesh(ABCMesh):
             face.uid = self._generate_uuid()
 
         if face.uid in self._faces:
-            error_str = "Trying to add an already existing face with uuid: "\
+            error_str = "Trying to add an already existing face with uid: "\
                 + str(face.uid)
             raise KeyError(error_str)
 
@@ -462,7 +462,7 @@ class Mesh(ABCMesh):
             cell.uid = self._generate_uuid()
 
         if cell.uid in self._cells:
-            error_str = "Trying to add an already existing cell with uuid: "\
+            error_str = "Trying to add an already existing cell with uid: "\
                 + str(cell.uid)
             raise KeyError(error_str)
 
@@ -548,7 +548,7 @@ class Mesh(ABCMesh):
         """ Updates the information of a face.
 
         Gets the mesh face identified by the same
-        uuid as the provided face and updates its information
+        uid as the provided face and updates its information
         with the one provided with the new face.
 
         Parameters
@@ -585,7 +585,7 @@ class Mesh(ABCMesh):
         """ Updates the information of a cell.
 
         Gets the mesh cell identified by the same
-        uuid as the provided cell and updates its information
+        uid as the provided cell and updates its information
         with the one provided with the new cell.
 
         Parameters
@@ -768,9 +768,9 @@ class Mesh(ABCMesh):
         return len(self._cells) > 0
 
     def _generate_uuid(self):
-        """ Provides and uuid for the object
+        """ Provides a uuid for the object
 
-        Provides san uuid as defined in the standard RFC 4122
+        Provides a uuid as defined in the standard RFC 4122
         """
 
         return uuid.uuid4()

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -331,7 +331,7 @@ class Mesh(ABCMesh):
         Returns
         -------
         Cell
-            Cell with id identified by uid
+            Cell identified by uid
 
         Raises
         ------

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -17,7 +17,7 @@ class Point(object):
 
     Parameters
     ----------
-    uid :
+    uid : uuid.UUID
         uid of the point.
     coordinates : list of double
         set of coordinates (x,y,z) describing the point position.
@@ -26,8 +26,8 @@ class Point(object):
 
     Attributes
     ----------
-    uid :
-        uuid of the point.
+    uid : uuid.UUID
+        uid of the point.
     data : DataContainer
         object to store point data
     coordinates : list of double
@@ -71,8 +71,8 @@ class Element(object):
     ----------
     points : list of uid
         list of points uids defining the element.
-    uid :
-        uuid of the element
+    uid : uuid.UUID
+        uid of the element
     data : DataContainer
         Element data
 
@@ -97,7 +97,7 @@ class Edge(Element):
     ----------
     points : list of uid
         list of points uids defining the edge.
-    uid :
+    uid : uuid.UUID
         uid of the edge.
     data : DataContainer
         object to store data relative to the edge
@@ -122,7 +122,7 @@ class Face(Element):
     ----------
     points : list of uid
         list of points uids defining the face.
-    uid :
+    uid : uuid.UUID
         uid of the face.
     data : DataContainer
         object to store data relative to the face
@@ -147,7 +147,7 @@ class Cell(Element):
     ----------
     points : list of uid
         list of points uids defining the cell.
-    uid :
+    uid : uuid.UUID
         uid of the cell.
     data : DataContainer
         object to store data relative to the cell
@@ -235,7 +235,7 @@ class Mesh(ABCMesh):
 
         Parameters
         ----------
-        uid
+        uid : uuid.UUID
             uid of the desired point.
 
         Returns
@@ -265,7 +265,7 @@ class Mesh(ABCMesh):
 
         Parameters
         ----------
-        uid
+        uid : uuid.UUID
             uid of the desired edge.
 
         Returns
@@ -295,7 +295,7 @@ class Mesh(ABCMesh):
 
         Parameters
         ----------
-        uid
+        uid : uuid.UUID
             uid of the desired face.
 
         Returns
@@ -325,7 +325,7 @@ class Mesh(ABCMesh):
 
         Parameters
         ----------
-        uid
+        uid : uuid.UUID
             uid of the desired cell.
 
         Returns
@@ -474,7 +474,7 @@ class Mesh(ABCMesh):
         """ Updates the information of a point.
 
         Gets the mesh point identified by the same
-        id as the provided point and updates its information
+        uid as the provided point and updates its information
         with the one provided with the new point.
 
         Parameters
@@ -511,7 +511,7 @@ class Mesh(ABCMesh):
         """ Updates the information of an edge.
 
         Gets the mesh edge identified by the same
-        id as the provided edge and updates its information
+        uid as the provided edge and updates its information
         with the one provided with the new edge.
 
         Parameters

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -276,19 +276,22 @@ class Particles(ABCParticles):
         """
         del self._bonds[uid]
 
-    def iter_particles(self, ids=None):
+    def iter_particles(self, uids=None):
         """Generator method for iterating over the particles of the container.
 
-        It can receive any kind of sequence of particle ids to iterate over
+        It can receive any kind of sequence of particle uids to iterate over
         those concrete particles. If nothing is passed as parameter, it will
         iterate over all the particles.
 
         Parameters
         ----------
 
-        ids : iterable
-            sequence containing the id's of the particles that will be
-            iterated.
+        uids : iterable of uuid.UUID, optional
+            sequence containing the uids of the particles that will be
+            iterated. When the uids are provided, then the particles are
+            returned in the same order the uids are returned by the iterable.
+            If uids is None, then all particles are returned by the interable
+            and there is no restriction on the order that they are returned.
 
         Yields
         ------
@@ -318,14 +321,14 @@ class Particles(ABCParticles):
                 #in case we need it
                 part_container.update_particle(particle)
         """
-        if ids is None:
+        if uids is None:
             return self._iter_all(
                 self._particles, clone=Particle.from_particle)
         else:
             return self._iter_elements(
-                self._particles, ids, clone=Particle.from_particle)
+                self._particles, uids, clone=Particle.from_particle)
 
-    def iter_bonds(self, ids=None):
+    def iter_bonds(self, uids=None):
         """Generator method for iterating over the bonds of the container.
 
         It can receive any kind of sequence of bond ids to iterate over
@@ -335,8 +338,12 @@ class Particles(ABCParticles):
         Parameters
         ----------
 
-        bond_ids : array_like
+        uids : iterable of uuid.UUID, optional
             sequence containing the id's of the bond that will be iterated.
+            When the uids are provided, then the bonds are returned in
+            the same order the uids are returned by the iterable. If uids is
+            None, then all bonds are returned by the interable and there
+            is no restriction on the order that they are returned.
 
         Yields
         ------
@@ -366,11 +373,11 @@ class Particles(ABCParticles):
                 part_container.update_bond(bond)
         """
 
-        if ids is None:
+        if uids is None:
             return self._iter_all(self._bonds, clone=Bond.from_bond)
         else:
             return self._iter_elements(
-                self._bonds, ids, clone=Bond.from_bond)
+                self._bonds, uids, clone=Bond.from_bond)
 
     def has_particle(self, uid):
         """Checks if a particle with the given id already exists

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -279,7 +279,7 @@ class Particles(ABCParticles):
     def iter_particles(self, ids=None):
         """Generator method for iterating over the particles of the container.
 
-        It can recieve any kind of sequence of particle ids to iterate over
+        It can receive any kind of sequence of particle ids to iterate over
         those concrete particles. If nothing is passed as parameter, it will
         iterate over all the particles.
 
@@ -302,7 +302,7 @@ class Particles(ABCParticles):
 
         Examples
         --------
-        It can be used with a sequence as parameter or withouth it:
+        It can be used with a sequence as parameter or without it:
 
         >>> part_container = Particles(name="foo")
         >>> ...
@@ -328,7 +328,7 @@ class Particles(ABCParticles):
     def iter_bonds(self, ids=None):
         """Generator method for iterating over the bonds of the container.
 
-        It can recieve any kind of sequence of bond ids to iterate over
+        It can receive any kind of sequence of bond ids to iterate over
         those concrete bond. If nothing is passed as parameter, it will
         iterate over all the bonds.
 

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -306,7 +306,7 @@ class Particles(ABCParticles):
 
         >>> part_container = Particles(name="foo")
         >>> ...
-        >>> for particle in part_container.iter_particles([id1, id2, id3]):
+        >>> for particle in part_container.iter_particles([uid1, uid2, uid3]):
                 ...  #do stuff
                 #take the particle back to the container so it will be updated
                 #in case we need it
@@ -349,7 +349,7 @@ class Particles(ABCParticles):
 
         Examples
         --------
-        It can be used with a sequence as parameter or withouth it:
+        It can be used with a sequence as parameter or without it:
 
         >>> part_container = Particles(name="foo")
         >>> ...
@@ -471,7 +471,7 @@ class Bond(object):
     uid : uuid.UUID
         the unique id of the bond
     particles : tuple
-        tuple of uuids of the particles that are participating in the bond.
+        tuple of uids of the particles that are participating in the bond.
     data : DataContainer
         DataContainer to store the attributes of the bond
 

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -49,7 +49,7 @@ class Particles(ABCParticles):
         """Adds the particle to the container.
 
         If the new particle has no uid, the particle container
-        will generate a new unique id for it. If the particle has
+        will generate a new uid for it. If the particle has
         already an uid, it won't add the particle if a particle
         with the same uid already exists. If the user wants to replace
         an existing particle in the container there is an 'update_particle'
@@ -87,7 +87,7 @@ class Particles(ABCParticles):
         Also like with particles, if the bond has a defined uid,
         it won't add the bond if a bond with the same uid already exists, and
         if the bond has no uid the particle container will generate an
-        unique uid. If the user wants to replace an existing bond in the
+        uid. If the user wants to replace an existing bond in the
         container there is an 'update_bond' method for that purpose.
 
         Parameters
@@ -151,7 +151,7 @@ class Particles(ABCParticles):
     def update_bond(self, bond):
         """Replaces an existing bond.
 
-        Takes the id of 'bond' and searchs inside the container for
+        Takes the uid of 'bond' and searchs inside the container for
         that bond. If the bond exists, it is replaced with the new
         bond passed as parameter. If the bond doesn't exist, it will
         raise an exception.
@@ -224,7 +224,7 @@ class Particles(ABCParticles):
     def remove_particle(self, uid):
         """Removes the particle with uid from the container.
 
-        The id passed as parameter should exists in the container. Otherwise
+        The uid passed as parameter should exists in the container. Otherwise
         an expcetion will be raised.
 
         Parameters
@@ -239,7 +239,7 @@ class Particles(ABCParticles):
 
         Examples
         --------
-        Having an id of an existing particle, pass it to the function.
+        Having an uid of an existing particle, pass it to the function.
 
         >>> part_container = Particles(name="foo")
         >>> ...
@@ -254,7 +254,7 @@ class Particles(ABCParticles):
     def remove_bond(self, uid):
         """Removes the bond with the uid from the container.
 
-        The id passed as parameter should exists in the container. If
+        The uid passed as parameter should exists in the container. If
         it doesn't exists, nothing will happen.
 
         Parameters
@@ -264,7 +264,7 @@ class Particles(ABCParticles):
 
         Examples
         --------
-        Having an id of an existing bond, pass it to the function.
+        Having an uid of an existing bond, pass it to the function.
 
         >>> part_container = Particles(name="foo")
         >>> ...
@@ -430,7 +430,7 @@ class Particle(object):
     Attributes
     ----------
     uid : uuid.UUID
-        the unique uid of the particle
+        the uid of the particle
     coordinates : list / tuple
         x,y,z coordinates of the particle
     data : DataContainer
@@ -476,7 +476,7 @@ class Bond(object):
     Attributes
     ----------
     uid : uuid.UUID
-        the unique id of the bond
+        the uid of the bond
     particles : tuple
         tuple of uids of the particles that are participating in the bond.
     data : DataContainer

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -48,10 +48,10 @@ class Particles(ABCParticles):
     def add_particle(self, particle):
         """Adds the particle to the container.
 
-        If the new particle has no id, the particle container
+        If the new particle has no uid, the particle container
         will generate a new unique id for it. If the particle has
-        already an id (user set), it won't add the particle if a particle
-        with the same id already exists. If the user wants to replace
+        already an uid, it won't add the particle if a particle
+        with the same uid already exists. If the user wants to replace
         an existing particle in the container there is an 'update_particle'
         method for that purpose.
 
@@ -63,7 +63,7 @@ class Particles(ABCParticles):
         Returns
         -------
         uid : uuid.UUID
-            The id of the added particle.
+            The uid of the added particle.
 
         Raises
         ------
@@ -84,10 +84,10 @@ class Particles(ABCParticles):
     def add_bond(self, bond):
         """Adds the bond to the container.
 
-        Also like with particles, if the bond has an user defined id,
-        it won't add the bond if a bond with the same id already exists, and
-        if the bond has no id the particle container will generate an
-        unique id. If the user wants to replace an existing bond in the
+        Also like with particles, if the bond has a defined uid,
+        it won't add the bond if a bond with the same uid already exists, and
+        if the bond has no uid the particle container will generate an
+        unique uid. If the user wants to replace an existing bond in the
         container there is an 'update_bond' method for that purpose.
 
         Parameters
@@ -98,7 +98,7 @@ class Particles(ABCParticles):
         Returns
         -------
         uid : uuid.UID
-            The id of the added bond.
+            The uid of the added bond.
 
         Raises
         ------
@@ -118,7 +118,7 @@ class Particles(ABCParticles):
     def update_particle(self, particle):
         """Replaces an existing particle.
 
-        Takes the id of 'particle' and searchs inside the container for
+        Takes the uid of 'particle' and searches inside the container for
         that particle. If the particle exists, it is replaced with the new
         particle passed as parameter. If the particle doesn't exist, it will
         raise an exception.
@@ -187,7 +187,7 @@ class Particles(ABCParticles):
         ----------
 
         uid : uuid.UUID
-            the id of the particle
+            the uid of the particle
 
         Raises
         ------
@@ -207,7 +207,7 @@ class Particles(ABCParticles):
         Parameters
         ----------
         uid : uuid.UUID
-            the id of the bond
+            the uid of the bond
 
         Raises
         ------
@@ -230,7 +230,7 @@ class Particles(ABCParticles):
         Parameters
         ----------
         uid : uuid.UUID
-            the id of the particle to be removed.
+            the uid of the particle to be removed.
 
         Raises
         ------
@@ -260,7 +260,7 @@ class Particles(ABCParticles):
         Parameters
         ----------
         uid : uuid.UUID
-            the id of the bond to be removed.
+            the uid of the bond to be removed.
 
         Examples
         --------
@@ -380,12 +380,12 @@ class Particles(ABCParticles):
                 self._bonds, uids, clone=Bond.from_bond)
 
     def has_particle(self, uid):
-        """Checks if a particle with the given id already exists
+        """Checks if a particle with the given uid already exists
         in the container."""
         return uid in self._particles
 
     def has_bond(self, uid):
-        """Checks if a bond with the given id already exists
+        """Checks if a bond with the given uid already exists
         in the container."""
         return uid in self._bonds
 
@@ -430,7 +430,7 @@ class Particle(object):
     Attributes
     ----------
     uid : uuid.UUID
-        the unique id of the particle
+        the unique uid of the particle
     coordinates : list / tuple
         x,y,z coordinates of the particle
     data : DataContainer
@@ -471,7 +471,7 @@ class Particle(object):
 
 
 class Bond(object):
-    """Class reprensenting a bond.
+    """Class representing a bond.
 
     Attributes
     ----------

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -283,7 +283,7 @@ class H5Mesh(object):
         Returns
         -------
         Cell
-            Cell with id identified by uid
+            Cell by uid
 
         Raises
         ------

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -283,7 +283,7 @@ class H5Mesh(object):
         Returns
         -------
         Cell
-            Cell by uid
+            Cell identified by uid
 
         Raises
         ------

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -170,7 +170,7 @@ class H5Mesh(object):
 
         Parameters
         ----------
-        uid : int
+        uid : UUID
             uid of the desired point.
 
         Returns

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -586,28 +586,25 @@ class H5Mesh(object):
                 existing cell with uid: " + str(cell.uid)
             raise KeyError(error_str)
 
-    def iter_points(self, point_uids=None):
-        """ Returns an iterator over the selected points.
-
-        Returns an interator over the points with uid in
-        point_uids. If non of the uids in point_uids exists,
-        an empty iterator is returned. If there is no uids
-        inside point_uids, a iterator over all points of
-        the mesh is returned instead.
+    def iter_points(self, uids=None):
+        """ Returns an iterator over points.
 
         Parameters
         ----------
-        point_uids : list of uid, optional
-            uids of the desired points, default empty
+        uids : iterable of uuid.UUID or None
+            When the uids are provided, then the points are returned in
+            the same order the uids are returned by the iterable. If uids is
+            None, then all points are returned by the interable and there
+            is no restriction on the order that they are returned.
 
         Returns
         -------
         iter
-            Iterator over the selected points
+            Iterator over the points
 
         """
 
-        if point_uids is None:
+        if uids is None:
             for row in self._group.points:
                 yield Point(
                     tuple(row['coordinates']),
@@ -615,22 +612,19 @@ class H5Mesh(object):
                     self._uidData[uuid.UUID(hex=row['data'], version=4)]
                 )
         else:
-            for point_uid in point_uids:
-                yield self.get_point(point_uid)
+            for uid in uids:
+                yield self.get_point(uid)
 
-    def iter_edges(self, edge_uids=None):
-        """ Returns an iterator over the selected edges.
-
-        Returns an interator over the edged with uid in
-        edge_uid. If non of the uids in edge_uids exists,
-        an empty iterator is returned. If there is no uids
-        inside edge_uids, a iterator over all edges of
-        the mesh is returned instead.
+    def iter_edges(self, uids=None):
+        """ Returns an iterator over edges.
 
         Parameters
         ----------
-        edge_uids : list of uid, optional
-            uids of the desired edges, default empty
+        uids : iterable of uuid.UUID  or None
+            When the uids are provided, then the edges are returned in the
+            same order the uids are returned by the iterable. If uids is None,
+            then all edges are returned by the interable and there is no
+            restriction on the order that they are returned.
 
         Returns
         -------
@@ -639,7 +633,7 @@ class H5Mesh(object):
 
         """
 
-        if edge_uids is None:
+        if uids is None:
             for row in self._group.edges:
                 yield Edge(
                     list(uuid.UUID(hex=pb, version=4) for pb in
@@ -648,31 +642,28 @@ class H5Mesh(object):
                     self._uidData[uuid.UUID(hex=row['data'], version=4)]
                 )
         else:
-            for edge_uid in edge_uids:
-                yield self.get_edge(edge_uid)
+            for uid in uids:
+                yield self.get_edge(uid)
 
-    def iter_faces(self, face_uids=None):
-        """ Returns an iterator over the selected faces.
-
-        Returns an interator over the faces with uid in
-        face_uids. If non of the ids in face_uids exists,
-        an empty iterator is returned. If there is no uids
-        inside face_uids, a iterator over all faces of
-        the mesh is returned instead.
+    def iter_faces(self, uids=None):
+        """ Returns an iterator over faces.
 
         Parameters
         ----------
-        face_uids : list of uid, optional
-            uids of the desired faces, default empty
+        uids : iterable of uuid.UUID  or None
+            When the uids are provided, then the faces are returned in the
+            same order the uids are returned by the iterable. If uids is None,
+            then all faces are returned by the interable and there is no
+            restriction on the order that they are returned.
 
         Returns
         -------
         iter
-            Iterator over the selected faces
+            Iterator over the faces
 
         """
 
-        if face_uids is None:
+        if uids is None:
             for row in self._group.faces:
                 yield Face(
                     list(uuid.UUID(hex=pb, version=4) for pb in
@@ -681,22 +672,19 @@ class H5Mesh(object):
                     self._uidData[uuid.UUID(hex=row['data'], version=4)]
                 )
         else:
-            for face_uid in face_uids:
-                yield self.get_face(face_uid)
+            for uid in uids:
+                yield self.get_face(uid)
 
-    def iter_cells(self, cell_uids=None):
-        """ Returns an iterator over the selected cells.
-
-        Returns an interator over the cells with uid in
-        cell_uids. If non of the ids in cell_uids exists,
-        an empty iterator is returned. If there is no uids
-        inside cell_uids, a iterator over all cells of
-        the mesh is returned instead.
+    def iter_cells(self, uids=None):
+        """ Returns an iterator over cells.
 
         Parameters
         ----------
-        cell_uids : list of UUID, optional
-            Uuds of the desired cell, default empty
+        uids : iterable of uuid.UUID  or None
+            When the uids are provided, then the cells are returned in the same
+            order the uids are returned by the iterable. If uids is None, then
+            all cells are returned by the interable and there is no restriction
+            on the order that they are returned.
 
         Returns
         -------
@@ -705,7 +693,7 @@ class H5Mesh(object):
 
         """
 
-        if cell_uids is None:
+        if uids is None:
             for row in self._group.cells:
                 yield Cell(
                     list(uuid.UUID(hex=pb, version=4) for pb in
@@ -714,8 +702,8 @@ class H5Mesh(object):
                     self._uidData[uuid.UUID(hex=row['data'], version=4)]
                 )
         else:
-            for cell_uid in cell_uids:
-                yield self.get_cell(cell_uid)
+            for uid in uids:
+                yield self.get_cell(uid)
 
     def has_edges(self):
         """ Check if the mesh container has edges

--- a/simphony/io/h5_particles.py
+++ b/simphony/io/h5_particles.py
@@ -196,7 +196,7 @@ class H5Particles(ABCParticles):
             return self._particles.itersequence(ids)
 
     def has_particle(self, uid):
-        """Checks if a particle with id "id" exists in the container."""
+        """Checks if a particle with uid "uid" exists in the container."""
         return uid in self._particles
 
     # Bond methods #######################################################
@@ -245,5 +245,5 @@ class H5Particles(ABCParticles):
             return self._bonds.itersequence(ids)
 
     def has_bond(self, uid):
-        """Checks if a bond with id "id" exists in the container."""
+        """Checks if a bond with uid "uid" exists in the container."""
         return uid in self._bonds

--- a/simphony/io/h5_particles.py
+++ b/simphony/io/h5_particles.py
@@ -31,7 +31,7 @@ class H5ParticleItems(H5CUDSItems):
     """ A proxy class to an HDF5 group node with serialised Particles
 
     The class implements the Mutable-Mapping api where each Particle
-    instance is mapped to uuid.
+    instance is mapped to uid.
 
 
     """
@@ -70,7 +70,7 @@ class H5BondItems(H5CUDSItems):
     """ A proxy class to an HDF5 group node with serialised Bonds
 
     The class implements the Mutable-Mapping api where each Bond
-    instance is mapped to uuid.
+    instance is mapped to uid.
 
 
     """
@@ -204,19 +204,19 @@ class H5Particles(ABCParticles):
     def add_bond(self, bond):
         """Add bond
 
-        If bond has an id then this is used.  If the
-        bond's id is None then a id is generated for the
+        If bond has an uid then this is used.  If the
+        bond's uid is None then a uid is generated for the
         bond.
 
         Returns
         -------
-        int :
-            id of bond
+        uid : uuid.UUID
+            uid of bond
 
         Raises
         ------
         ValueError :
-           if an id is given which already exists.
+           if an uid is given which already exists.
 
         """
         uid = bond.uid


### PR DESCRIPTION
This addresses #127.

All the the docstrings are updated to clarify the spefic order of items by the CUDS items iterators (e.g. iter_points()).

