### PR TITLE
PR: Lattice attributes are always 3D.

### DIFF
--- a/simphony/cuds/abstractlattice.py
+++ b/simphony/cuds/abstractlattice.py
@@ -10,11 +10,11 @@ class ABCLattice(object):
         name of lattice
     type : str
         type of lattice
-    base_vect : D x float
+    base_vect : float[3]
         base vector of lattice
-    size : tuple of D x int
+    size : tuple of int[3]
         lattice dimensions
-    origin : D x float
+    origin : float[3]
         lattice origin
     data : DataContainer
         high level CUBA data assigned to lattice
@@ -28,7 +28,7 @@ class ABCLattice(object):
 
         Parameters
         ----------
-        index : tuple of D x int
+        index : int[3]
             node index coordinate
 
         Returns
@@ -53,11 +53,11 @@ class ABCLattice(object):
 
         Parameters
         ----------
-        indices : iterable set of D x int, optional
+        indices : iterable set of int[3], optional
             When indices (i.e. node index coordinates) are provided, then nodes
             are returned in the same order of the provided indices. If indices
             is None, there is no restriction on the order the nodes that are
-            are returned.
+            returned.
 
         Returns
         -------
@@ -72,11 +72,11 @@ class ABCLattice(object):
 
         Parameters
         ----------
-        index : D x int
+        index : int[3]
             node index coordinate
 
         Returns
         -------
-        coordinates : D x float
+        coordinates : float[3]
 
         """

--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -9,8 +9,8 @@ class LatticeNode(object):
 
     Attributes
     ----------
-    index : tuple of D x int
-        D dimensional node index coordinate
+    index : tuple of int[3]
+        node index coordinate
     data : DataContainer
 
     """
@@ -33,12 +33,12 @@ class Lattice(ABCLattice):
         name of the lattice
     type : str
         Bravais lattice type (should agree with the base_vect below).
-    base_vect : D x float
-        defines a Bravais lattice of dimension D = 2,3
+    base_vect : float[3]
+        defines a Bravais lattice
         (an alternative for primitive vectors).
-    size : tuple of D x int
+    size : tuple of int[3]
         number of lattice nodes in the direction of each axis.
-    origin : D x float
+    origin : float[3]
         origin of lattice
 
     """
@@ -57,7 +57,8 @@ class Lattice(ABCLattice):
 
         Parameters
         ----------
-        index : tuple of D x int (node index coordinate)
+        index : int[3]
+            node index coordinate
 
         Returns
         -------
@@ -88,11 +89,11 @@ class Lattice(ABCLattice):
 
         Parameters
         ----------
-        indices : iterable set of D x int, optional
+        indices : iterable set of int[3], optional
             When indices (i.e. node index coordinates) are provided, then nodes
             are returned in the same order of the provided indices. If indices
             is None, there is no restriction on the order the nodes that are
-            are returned.
+            returned.
 
         Returns
         -------
@@ -111,11 +112,12 @@ class Lattice(ABCLattice):
 
         Parameters
         ----------
-        index : D x int (node index coordinate)
+        index : int[3]
+            node index coordinate
 
         Returns
         -------
-        D x float
+        float[3]
 
         """
         if self._type == 'Hexagonal':
@@ -149,17 +151,18 @@ class Lattice(ABCLattice):
 
 
 def make_hexagonal_lattice(name, h, size, origin=(0, 0)):
-    """Create and return a 2D hexagonal lattice.
+    """Create and return a 2D hexagonal lattice embedded on the XY-plane
+    in 3D.
 
     Parameters
     ----------
     name : str
     h : float
-        lattice spacing.
-    size : 2 x int
-        number of lattice nodes (in each axis direction).
-    origin : 2 x float (default value = (0,0))
-        lattice origin.
+        lattice spacing
+    size : int[2]
+        Number of lattice nodes in each axis direction.
+    origin : float[2], default value = (0, 0)
+        lattice origin
 
     Returns
     -------
@@ -167,21 +170,23 @@ def make_hexagonal_lattice(name, h, size, origin=(0, 0)):
         A reference to a Lattice object.
 
     """
-    return Lattice(name, 'Hexagonal', (0.5*h, 0.5*sqrt(3)*h), size, origin)
+    return Lattice(name, 'Hexagonal', (0.5*h, 0.5*sqrt(3)*h, 0),
+                   tuple(size)+(1,), tuple(origin)+(0,))
 
 
 def make_square_lattice(name, h, size, origin=(0, 0)):
-    """Create and return a 2D square lattice.
+    """Create and return a 2D square lattice embedded on the XY-plane
+    in 3D.
 
     Parameters
     ----------
     name : str
     h : float
-        lattice spacing.
-    size : 2 x int
-        number of lattice nodes (in each axis direction).
-    origin : 2 x float (default value = (0,0))
-        lattice origin.
+        lattice spacing
+    size : int[2]
+        Number of lattice nodes in each axis direction.
+    origin : float[2], default value = (0, 0)
+        lattice origin
 
     Returns
     -------
@@ -189,21 +194,23 @@ def make_square_lattice(name, h, size, origin=(0, 0)):
         A reference to a Lattice object.
 
     """
-    return Lattice(name, 'Square', (h, h), size, origin)
+    return Lattice(name, 'Square', (h, h, 0), tuple(size)+(1,),
+                   tuple(origin)+(0,))
 
 
 def make_rectangular_lattice(name, hs, size, origin=(0, 0)):
-    """Create and return a 2D rectangular lattice.
+    """Create and return a 2D rectangular lattice embedded on the XY-plane
+    in 3D.
 
     Parameters
     ----------
     name : str
-    hs : 2 x float
-        lattice spacings (in each axis direction).
-    size : 2 x int
-        number of lattice nodes (in each axis direction).
-    origin : 2 x float (default value = (0,0))
-        lattice origin.
+    hs : float[2]
+        lattice spacings in each axis direction
+    size : int[2]
+        Number of lattice nodes in each axis direction.
+    origin : float[2], default value = (0, 0)
+        lattice origin
 
     Returns
     -------
@@ -211,7 +218,8 @@ def make_rectangular_lattice(name, hs, size, origin=(0, 0)):
         A reference to a Lattice object.
 
     """
-    return Lattice(name, 'Rectangular', hs, size, origin)
+    return Lattice(name, 'Rectangular', tuple(hs)+(0,), tuple(size)+(1,),
+                   tuple(origin)+(0,))
 
 
 def make_cubic_lattice(name, h, size, origin=(0, 0, 0)):
@@ -221,11 +229,11 @@ def make_cubic_lattice(name, h, size, origin=(0, 0, 0)):
     ----------
     name : str
     h : float
-        lattice spacing.
-    size : 3 x int
-        number of lattice nodes (in each axis direction).
-    origin : 3 x float (default value = (0,0,0))
-        lattice origin.
+        lattice spacing
+    size : int[3]
+        Number of lattice nodes in each axis direction.
+    origin : float[3], default value = (0, 0, 0)
+        lattice origin
 
     Returns
     -------
@@ -242,12 +250,12 @@ def make_orthorombicp_lattice(name, hs, size, origin=(0, 0, 0)):
     Parameters
     ----------
     name : str
-    hs : 3 x float
-        lattice spacings (in each axis direction).
-    size : 3 x int
-        number of lattice nodes (in each axis direction).
-    origin : 3 x float (default value = (0,0,0))
-        lattice origin.
+    hs : float[3]
+        lattice spacings in each axis direction
+    size : int[3]
+        Number of lattice nodes in each axis direction.
+    origin : float[3], default value = (0, 0, 0)
+        lattice origin
 
     Returns
     -------

--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -15,7 +15,7 @@ class LatticeNode(object):
 
     """
     def __init__(self, index, data=None):
-        self.index = tuple(index)
+        self.index = index[0], index[1], index[2]
 
         if data is None:
             self.data = DataContainer()
@@ -46,9 +46,11 @@ class Lattice(ABCLattice):
     def __init__(self, name, type, base_vect, size, origin):
         self.name = name
         self._type = type
-        self._base_vect = np.array(base_vect, dtype=np.float)
-        self._size = tuple(size)
-        self._origin = np.array(origin, dtype=np.float)
+        self._base_vect = np.array((base_vect[0], base_vect[1],
+                                    base_vect[2]), dtype=np.float)
+        self._size = size[0], size[1], size[2]
+        self._origin = np.array((origin[0], origin[1], origin[2]),
+                                dtype=np.float)
         self._dcs = np.empty(size, dtype=object)
         self._data = DataContainer()
 
@@ -66,7 +68,7 @@ class Lattice(ABCLattice):
 
         """
         tuple_index = tuple(index)
-        if any(value < 0 for value in tuple_index):
+        if tuple_index[0] < 0 or tuple_index[1] < 0 or tuple_index[2] < 0:
             raise IndexError('invalid index: {}'.format(tuple_index))
         return LatticeNode(tuple_index, self._dcs[tuple_index])
 
@@ -150,7 +152,7 @@ class Lattice(ABCLattice):
         self._data = DataContainer(value)
 
 
-def make_hexagonal_lattice(name, h, size, origin=(0, 0)):
+def make_hexagonal_lattice(name, h, size, origin=(0, 0, 0)):
     """Create and return a 2D hexagonal lattice embedded on the XY-plane
     in 3D.
 
@@ -161,7 +163,7 @@ def make_hexagonal_lattice(name, h, size, origin=(0, 0)):
         lattice spacing
     size : int[2]
         Number of lattice nodes in each axis direction.
-    origin : float[2], default value = (0, 0)
+    origin : float[3], default value = (0, 0, 0)
         lattice origin
 
     Returns
@@ -171,10 +173,10 @@ def make_hexagonal_lattice(name, h, size, origin=(0, 0)):
 
     """
     return Lattice(name, 'Hexagonal', (0.5*h, 0.5*sqrt(3)*h, 0),
-                   tuple(size)+(1,), tuple(origin)+(0,))
+                   tuple(size)+(1,), (origin[0], origin[1])+(0,))
 
 
-def make_square_lattice(name, h, size, origin=(0, 0)):
+def make_square_lattice(name, h, size, origin=(0, 0, 0)):
     """Create and return a 2D square lattice embedded on the XY-plane
     in 3D.
 
@@ -185,7 +187,7 @@ def make_square_lattice(name, h, size, origin=(0, 0)):
         lattice spacing
     size : int[2]
         Number of lattice nodes in each axis direction.
-    origin : float[2], default value = (0, 0)
+    origin : float[3], default value = (0, 0, 0)
         lattice origin
 
     Returns
@@ -195,10 +197,10 @@ def make_square_lattice(name, h, size, origin=(0, 0)):
 
     """
     return Lattice(name, 'Square', (h, h, 0), tuple(size)+(1,),
-                   tuple(origin)+(0,))
+                   (origin[0], origin[1])+(0,))
 
 
-def make_rectangular_lattice(name, hs, size, origin=(0, 0)):
+def make_rectangular_lattice(name, hs, size, origin=(0, 0, 0)):
     """Create and return a 2D rectangular lattice embedded on the XY-plane
     in 3D.
 
@@ -209,7 +211,7 @@ def make_rectangular_lattice(name, hs, size, origin=(0, 0)):
         lattice spacings in each axis direction
     size : int[2]
         Number of lattice nodes in each axis direction.
-    origin : float[2], default value = (0, 0)
+    origin : float[3], default value = (0, 0, 0)
         lattice origin
 
     Returns
@@ -219,7 +221,7 @@ def make_rectangular_lattice(name, hs, size, origin=(0, 0)):
 
     """
     return Lattice(name, 'Rectangular', tuple(hs)+(0,), tuple(size)+(1,),
-                   tuple(origin)+(0,))
+                   (origin[0], origin[1])+(0,))
 
 
 def make_cubic_lattice(name, h, size, origin=(0, 0, 0)):

--- a/simphony/cuds/tests/test_lattice.py
+++ b/simphony/cuds/tests/test_lattice.py
@@ -18,25 +18,25 @@ class LatticeNodeTestCase(unittest.TestCase):
 
     def test_construct_lattice_node_default(self):
         """Creation of a lattice node."""
-        node = LatticeNode((0, 0))
+        node = LatticeNode((0, 0, 0))
 
         self.assertIsInstance(node, LatticeNode,
                               "Error: not a LatticeNode!")
-        self.assertEqual(node.index, (0, 0))
+        self.assertEqual(node.index, (0, 0, 0))
 
     def test_construct_lattice_node_copy(self):
         """Creation of a lattice node (copy constructor)."""
-        node_org = LatticeNode((0, 1))
+        node_org = LatticeNode((0, 0, 1))
         node_org.data[CUBA.DENSITY] = 1.5
-        node_org.data[CUBA.VELOCITY] = (0.2, -0.1)
+        node_org.data[CUBA.VELOCITY] = (0.2, -0.1, 0.0)
 
-        node_new = LatticeNode((2, 3), node_org.data)
+        node_new = LatticeNode((2, 3, 1), node_org.data)
 
         self.assertIsInstance(node_new, LatticeNode,
                               "Error: not a LatticeNode!")
-        self.assertEqual(node_new.index, (2, 3))
+        self.assertEqual(node_new.index, (2, 3, 1))
         self.assertEqual(node_new.data[CUBA.DENSITY], 1.5)
-        self.assertEqual(node_new.data[CUBA.VELOCITY], (0.2, -0.1))
+        self.assertEqual(node_new.data[CUBA.VELOCITY], (0.2, -0.1, 0.0))
 
 
 class TestLattice(ABCCheckLattice, unittest.TestCase):
@@ -79,21 +79,22 @@ class TestLattice(ABCCheckLattice, unittest.TestCase):
         self.assertEqual(cubic_lat.type, 'Cubic')
         self.assertEqual(orthop_lat.type, 'OrthorombicP')
 
-        assert_array_equal(hexag_lat.size, (11, 21))
-        assert_array_equal(square_lat.size, (12, 22))
-        assert_array_equal(rectang_lat.size, (13, 23))
+        assert_array_equal(hexag_lat.size, (11, 21, 1))
+        assert_array_equal(square_lat.size, (12, 22, 1))
+        assert_array_equal(rectang_lat.size, (13, 23, 1))
         assert_array_equal(cubic_lat.size, (14, 24, 34))
         assert_array_equal(orthop_lat.size, (15, 25, 35))
 
-        assert_array_equal(hexag_lat.origin, (0, 0))
-        assert_array_equal(square_lat.origin, (0, 0))
-        assert_array_equal(rectang_lat.origin, (0, 0))
+        assert_array_equal(hexag_lat.origin, (0, 0, 0))
+        assert_array_equal(square_lat.origin, (0, 0, 0))
+        assert_array_equal(rectang_lat.origin, (0, 0, 0))
         assert_array_equal(cubic_lat.origin, (4, 5, 6))
         assert_array_equal(orthop_lat.origin, (7, 8, 9))
 
-        assert_array_equal(hexag_lat.base_vect, (0.5*0.1, 0.5*sqrt(3)*0.1))
-        assert_array_equal(square_lat.base_vect, (0.2, 0.2))
-        assert_array_equal(rectang_lat.base_vect, (0.3, 0.35))
+        assert_array_equal(hexag_lat.base_vect,
+                           (0.5*0.1, 0.5*sqrt(3)*0.1, 0))
+        assert_array_equal(square_lat.base_vect, (0.2, 0.2, 0))
+        assert_array_equal(rectang_lat.base_vect, (0.3, 0.35, 0))
         assert_array_equal(cubic_lat.base_vect, (0.4, 0.4, 0.4))
         assert_array_equal(orthop_lat.base_vect, (0.5, 0.54, 0.58))
 

--- a/simphony/io/h5_lattice.py
+++ b/simphony/io/h5_lattice.py
@@ -41,11 +41,11 @@ class H5Lattice(ABCLattice):
             for lattice and data will be located
         type : str
             Bravais lattice type (should agree with the _base_vect below).
-        base_vect : D x float
+        base_vect : float[3]
             defines a Bravais lattice (an alternative for primitive vectors).
-        size : D x size
+        size : int[3]
             number of lattice nodes (in the direction of each axis).
-        origin : D x float
+        origin : float[3]
             origin of lattice
         record : tables.IsDescription
             A class that describes column types for PyTables table.
@@ -60,7 +60,7 @@ class H5Lattice(ABCLattice):
 
         lattice._table.attrs.type = type
         lattice._table.attrs.base_vect = base_vect
-        lattice._table.attrs.size = size
+        lattice._table.attrs.size = tuple(size)
         lattice._table.attrs.origin = origin
 
         IndexedDataContainerTable(group, 'data', NoUIDRecord, 1)
@@ -72,7 +72,8 @@ class H5Lattice(ABCLattice):
 
         Parameters
         ----------
-        index : tuple of D x int (node index coordinate)
+        index : int[3]
+            node index coordinate
 
         Returns
         -------
@@ -86,12 +87,12 @@ class H5Lattice(ABCLattice):
         return LatticeNode(index, self._table[n])
 
     def update_node(self, node):
-        """ Updates FileLattice data for a LatticeNode
+        """ Updates H5Lattice data for a LatticeNode
 
         Parameters
         ----------
-            node : LatticeNode
-                reference to LatticeNode object
+        node : LatticeNode
+            reference to LatticeNode object
 
         """
         # Find correct row for node
@@ -107,7 +108,7 @@ class H5Lattice(ABCLattice):
 
         Parameters
         ----------
-        indices : iterable set of D x int, optional
+        indices : iterable set of int[3], optional
             node index coordinates
 
         Returns
@@ -128,11 +129,12 @@ class H5Lattice(ABCLattice):
 
         Parameters
         ----------
-        index : D x int (node index coordinate)
+        index : int[3]
+            node index coordinate
 
         Returns
         -------
-        D x float
+        float[3]
 
         """
         if self._type == 'Hexagonal':

--- a/simphony/testing/abc_check_lattice.py
+++ b/simphony/testing/abc_check_lattice.py
@@ -163,12 +163,15 @@ class ABCCheckLattice(object):
             default.base_vect,
             default.size,
             default.origin)
-        xspace, yspace = default.base_vect
-        x, y = numpy.meshgrid(range(default.size[0]), range(default.size[1]))
-        indexes = zip(x.flat, y.flat)
+        xspace, yspace, zspace = default.base_vect
+        x, y, z = numpy.meshgrid(range(default.size[0]),
+                                 range(default.size[1]),
+                                 range(default.size[2]))
+        indexes = zip(x.flat, y.flat, z.flat)
         expected = zip(
             x.ravel() * xspace + default.origin[0],
-            y.ravel() * yspace + default.origin[1])
+            y.ravel() * yspace + default.origin[1],
+            z.ravel() * zspace + default.origin[2])
 
         for i, index in enumerate(indexes):
             assert_array_equal(container.get_coordinate(index), expected[i])
@@ -182,12 +185,15 @@ class ABCCheckLattice(object):
             default.base_vect,
             default.size,
             default.origin)
-        xspace, yspace = default.base_vect
-        x, y = numpy.meshgrid(range(default.size[0]), range(default.size[1]))
-        indexes = zip(x.flat, y.flat)
+        xspace, yspace, zspace = default.base_vect
+        x, y, z = numpy.meshgrid(range(default.size[0]),
+                                 range(default.size[1]),
+                                 range(default.size[2]))
+        indexes = zip(x.flat, y.flat, z.flat)
         expected = zip(
             x.ravel() * xspace + default.origin[0],
-            y.ravel() * yspace + default.origin[1])
+            y.ravel() * yspace + default.origin[1],
+            z.ravel() * zspace + default.origin[2])
 
         for i, index in enumerate(indexes):
             assert_array_equal(container.get_coordinate(index), expected[i])


### PR DESCRIPTION
This PR fixed #80. Please, note that documentation is not modified yet.

Changes:
abstractlattice.py:
* replaced "D x " notation with [3] in docstrings

lattice.py:
* replaced "D x " notation with [3] in docstrings
* factory functions always create 3D Lattices. 2D lattice is embedded on the XY-plane in 3D. This is due to decision by the SSB that the 3rd coordinate is ignored for 2D lattices.
* factory functions still require correct dimensions for lattice parameters, e.g. two dimensions for the size of 2D lattice.

test_lattice.py:
* changed all 2D variables to 3D except in factory functions by adding 0 or 1

h5lattice.py:
* replaced "D x " notation with [3] in docstrings

abc_check_lattice.py:
* tests for 2D-lattices now use 3D attributes



