### PR TITLE
Cleanup lattice test templates

### DIFF
--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -123,9 +123,14 @@ class Lattice(ABCLattice):
 
         """
         if self._type == 'Hexagonal':
-            raise NotImplementedError("""Get_coordinate for
-                Hexagonal system not implemented!""")
-        return self.origin + self.base_vect*np.array(index)
+            xorigin, yorigin, zorigin = self.origin
+            xspace, yspace, zspace = self.base_vect
+            x = xorigin + index[0] * xspace * 0.5 * xspace * index[1] % 2
+            y = yorigin + index[1] * yspace
+            z = zorigin
+            return x, y, z
+        else:
+            return self.origin + self.base_vect*np.array(index)
 
     @property
     def type(self):

--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -125,7 +125,7 @@ class Lattice(ABCLattice):
         if self._type == 'Hexagonal':
             xorigin, yorigin, zorigin = self.origin
             xspace, yspace, zspace = self.base_vect
-            x = xorigin + index[0] * xspace * 0.5 * xspace * index[1] % 2
+            x = xorigin + index[0] * xspace + 0.5 * xspace * index[1]
             y = yorigin + index[1] * yspace
             z = zorigin
             return x, y, z

--- a/simphony/cuds/tests/test_lattice.py
+++ b/simphony/cuds/tests/test_lattice.py
@@ -6,11 +6,12 @@ from numpy.testing import assert_array_equal
 from math import sqrt
 
 from simphony.core.cuba import CUBA
-from simphony.testing.abc_check_lattice import ABCCheckLattice
+from simphony.testing.abc_check_lattice import (
+    CheckLatticeProperties, CheckLatticeNodeOperations,
+    CheckLatticeNodeCoordinates)
 from simphony.cuds.lattice import (
     Lattice, LatticeNode, make_cubic_lattice, make_rectangular_lattice,
     make_square_lattice, make_orthorombicp_lattice, make_hexagonal_lattice)
-from simphony.core.data_container import DataContainer
 
 
 class LatticeNodeTestCase(unittest.TestCase):
@@ -20,8 +21,7 @@ class LatticeNodeTestCase(unittest.TestCase):
         """Creation of a lattice node."""
         node = LatticeNode((0, 0, 0))
 
-        self.assertIsInstance(node, LatticeNode,
-                              "Error: not a LatticeNode!")
+        self.assertIsInstance(node, LatticeNode)
         self.assertEqual(node.index, (0, 0, 0))
 
     def test_construct_lattice_node_copy(self):
@@ -32,14 +32,13 @@ class LatticeNodeTestCase(unittest.TestCase):
 
         node_new = LatticeNode((2, 3, 1), node_org.data)
 
-        self.assertIsInstance(node_new, LatticeNode,
-                              "Error: not a LatticeNode!")
+        self.assertIsInstance(node_new, LatticeNode)
         self.assertEqual(node_new.index, (2, 3, 1))
         self.assertEqual(node_new.data[CUBA.DENSITY], 1.5)
         self.assertEqual(node_new.data[CUBA.VELOCITY], (0.2, -0.1, 0.0))
 
 
-class TestLattice(ABCCheckLattice, unittest.TestCase):
+class TestLatticeNodeOperations(CheckLatticeNodeOperations, unittest.TestCase):
 
     def container_factory(self, name, type_, base_vect, size, origin):
         return Lattice(name, type_, base_vect, size, origin)
@@ -47,88 +46,83 @@ class TestLattice(ABCCheckLattice, unittest.TestCase):
     def supported_cuba(self):
         return set(CUBA)
 
-    def test_construct_lattice_make(self):
-        """ Test creation of lattices using the factory functions.
 
-        """
+class TestLatticeNodeCoordinates(
+        CheckLatticeNodeCoordinates, unittest.TestCase):
 
-        hexag_lat = make_hexagonal_lattice('Lattice1', 0.1, (11, 21))
-        square_lat = make_square_lattice('Lattice2', 0.2, (12, 22))
-        rectang_lat = make_rectangular_lattice(
-            'Lattice3', (0.3, 0.35), (13, 23))
-        cubic_lat = make_cubic_lattice(
-            'Lattice4', 0.4, (14, 24, 34), (4, 5, 6))
-        orthop_lat = make_orthorombicp_lattice(
+    def container_factory(self, name, type_, base_vect, size, origin):
+        return Lattice(name, type_, base_vect, size, origin)
+
+    def supported_cuba(self):
+        return set(CUBA)
+
+    @unittest.skip('Hexagonal coordinates are not supported yet')
+    def test_get_coordinate_hexagonal(self):
+        pass
+
+
+class TestLatticeProperties(CheckLatticeProperties, unittest.TestCase):
+
+    def container_factory(self, name, type_, base_vect, size, origin):
+        return Lattice(name, type_, base_vect, size, origin)
+
+    def supported_cuba(self):
+        return set(CUBA)
+
+
+class TestLatticeFactories(unittest.TestCase):
+
+    def test_make_hexagonal(self):
+        lattice = make_hexagonal_lattice('Lattice1', 0.1, (11, 21))
+
+        self.assertIsInstance(lattice, Lattice)
+        self.assertEqual(lattice.name, 'Lattice1')
+        self.assertEqual(lattice.type, 'Hexagonal')
+        assert_array_equal(lattice.size, (11, 21, 1))
+        assert_array_equal(lattice.origin, (0, 0, 0))
+        assert_array_equal(lattice.base_vect,
+                           (0.5*0.1, 0.5*sqrt(3)*0.1, 0))
+
+    def test_make_square(self):
+        lattice = make_square_lattice('Lattice2', 0.2, (12, 22))
+
+        self.assertIsInstance(lattice, Lattice)
+        self.assertEqual(lattice.name, 'Lattice2')
+        self.assertEqual(lattice.type, 'Square')
+        assert_array_equal(lattice.size, (12, 22, 1))
+        assert_array_equal(lattice.origin, (0, 0, 0))
+        assert_array_equal(lattice.base_vect, (0.2, 0.2, 0))
+
+    def test_make_cubic(self):
+        lattice = make_cubic_lattice('Lattice4', 0.4, (14, 24, 34), (4, 5, 6))
+
+        self.assertIsInstance(lattice, Lattice)
+        self.assertEqual(lattice.name, 'Lattice4')
+        self.assertEqual(lattice.type, 'Cubic')
+        assert_array_equal(lattice.size, (14, 24, 34))
+        assert_array_equal(lattice.origin, (4, 5, 6))
+        assert_array_equal(lattice.base_vect, (0.4, 0.4, 0.4))
+
+    def test_make_rectangular(self):
+        lattice = make_rectangular_lattice('Lattice3', (0.3, 0.35), (13, 23))
+
+        self.assertIsInstance(lattice, Lattice)
+        self.assertEqual(lattice.name, 'Lattice3')
+        self.assertEqual(lattice.type, 'Rectangular')
+        assert_array_equal(lattice.size, (13, 23, 1))
+        assert_array_equal(lattice.origin, (0, 0, 0))
+        assert_array_equal(lattice.base_vect, (0.3, 0.35, 0))
+
+    def test_orthorombicp_lattice(self):
+        lattice = make_orthorombicp_lattice(
             'Lattice5', (0.5, 0.54, 0.58), (15, 25, 35), (7, 8, 9))
 
-        self.assertIsInstance(hexag_lat, Lattice, "Error: not a Lattice!")
-        self.assertIsInstance(square_lat, Lattice, "Error: not a Lattice!")
-        self.assertIsInstance(rectang_lat, Lattice, "Error: not a Lattice!")
-        self.assertIsInstance(cubic_lat, Lattice, "Error: not a Lattice!")
-        self.assertIsInstance(orthop_lat, Lattice, "Error: not a Lattice!")
-
-        self.assertEqual(hexag_lat.name, 'Lattice1')
-        self.assertEqual(square_lat.name, 'Lattice2')
-        self.assertEqual(rectang_lat.name, 'Lattice3')
-        self.assertEqual(cubic_lat.name, 'Lattice4')
-        self.assertEqual(orthop_lat.name, 'Lattice5')
-
-        self.assertEqual(hexag_lat.type, 'Hexagonal')
-        self.assertEqual(square_lat.type, 'Square')
-        self.assertEqual(rectang_lat.type, 'Rectangular')
-        self.assertEqual(cubic_lat.type, 'Cubic')
-        self.assertEqual(orthop_lat.type, 'OrthorombicP')
-
-        assert_array_equal(hexag_lat.size, (11, 21, 1))
-        assert_array_equal(square_lat.size, (12, 22, 1))
-        assert_array_equal(rectang_lat.size, (13, 23, 1))
-        assert_array_equal(cubic_lat.size, (14, 24, 34))
-        assert_array_equal(orthop_lat.size, (15, 25, 35))
-
-        assert_array_equal(hexag_lat.origin, (0, 0, 0))
-        assert_array_equal(square_lat.origin, (0, 0, 0))
-        assert_array_equal(rectang_lat.origin, (0, 0, 0))
-        assert_array_equal(cubic_lat.origin, (4, 5, 6))
-        assert_array_equal(orthop_lat.origin, (7, 8, 9))
-
-        assert_array_equal(hexag_lat.base_vect,
-                           (0.5*0.1, 0.5*sqrt(3)*0.1, 0))
-        assert_array_equal(square_lat.base_vect, (0.2, 0.2, 0))
-        assert_array_equal(rectang_lat.base_vect, (0.3, 0.35, 0))
-        assert_array_equal(cubic_lat.base_vect, (0.4, 0.4, 0.4))
-        assert_array_equal(orthop_lat.base_vect, (0.5, 0.54, 0.58))
-
-    def test_set_modify_data(self):
-        """ Check that data can be retrieved and is consistent. Check that
-        the internal data of the lattice cannot be modified outside the
-        lattice class
-        """
-        lattice = self.container_factory('test_lat', 'Cubic',
-                                         (1.0, 1.0, 1.0), (4, 3, 2),
-                                         (0, 0, 0))
-        org_data = DataContainer()
-
-        org_data[CUBA.VELOCITY] = (0, 0, 0)
-
-        lattice.data = org_data
-        ret_data = lattice.data
-
-        self.assertEqual(org_data, ret_data)
-        self.assertIsNot(org_data, ret_data)
-
-        org_data = DataContainer()
-
-        org_data[CUBA.VELOCITY] = (0, 0, 0)
-
-        lattice.data = org_data
-        mod_data = lattice.data
-
-        mod_data[CUBA.VELOCITY] = (1, 1, 1)
-
-        ret_data = lattice.data
-
-        self.assertEqual(org_data, ret_data)
-        self.assertIsNot(org_data, ret_data)
+        self.assertIsInstance(lattice, Lattice)
+        self.assertEqual(lattice.name, 'Lattice5')
+        self.assertEqual(lattice.type, 'OrthorombicP')
+        assert_array_equal(lattice.size, (15, 25, 35))
+        assert_array_equal(lattice.origin, (7, 8, 9))
+        assert_array_equal(lattice.base_vect, (0.5, 0.54, 0.58))
 
 
 if __name__ == '__main__':

--- a/simphony/cuds/tests/test_lattice.py
+++ b/simphony/cuds/tests/test_lattice.py
@@ -56,10 +56,6 @@ class TestLatticeNodeCoordinates(
     def supported_cuba(self):
         return set(CUBA)
 
-    @unittest.skip('Hexagonal coordinates are not supported yet')
-    def test_get_coordinate_hexagonal(self):
-        pass
-
 
 class TestLatticeProperties(CheckLatticeProperties, unittest.TestCase):
 

--- a/simphony/io/h5_lattice.py
+++ b/simphony/io/h5_lattice.py
@@ -138,10 +138,14 @@ class H5Lattice(ABCLattice):
 
         """
         if self._type == 'Hexagonal':
-            raise NotImplementedError("""Get_coordinate for
-                Hexagonal system not implemented!""")
-
-        return self._origin + self._base_vect*np.array(index)
+            xorigin, yorigin, zorigin = self.origin
+            xspace, yspace, zspace = self.base_vect
+            x = xorigin + index[0] * xspace + 0.5 * xspace * index[1]
+            y = yorigin + index[1] * yspace
+            z = zorigin
+            return x, y, z
+        else:
+            return self.origin + self.base_vect*np.array(index)
 
     @property
     def type(self):

--- a/simphony/io/tests/test_h5_lattice.py
+++ b/simphony/io/tests/test_h5_lattice.py
@@ -82,6 +82,7 @@ class TestH5LatticeNodeCoordinates(
     def test_get_coordinate_hexagonal(self):
         pass
 
+
 class TestH5LatticeNodeOperations(
         CheckLatticeNodeOperations, unittest.TestCase):
 

--- a/simphony/io/tests/test_h5_lattice.py
+++ b/simphony/io/tests/test_h5_lattice.py
@@ -7,8 +7,9 @@ import tables
 from simphony.io.h5_lattice import H5Lattice
 from numpy.testing import assert_array_equal
 from simphony.core.cuba import CUBA
-from simphony.testing.abc_check_lattice import ABCCheckLattice
-from simphony.core.data_container import DataContainer
+from simphony.testing.abc_check_lattice import (
+    CheckLatticeProperties, CheckLatticeNodeOperations,
+    CheckLatticeNodeCoordinates)
 
 
 class CustomRecord(tables.IsDescription):
@@ -22,16 +23,14 @@ class CustomRecord(tables.IsDescription):
     mask = tables.BoolCol(pos=1, shape=(3,))
 
 
-class TestH5Lattice(ABCCheckLattice, unittest.TestCase):
-    """ Basic testing of the H5Lattice.
-    """
+class TestH5LatticeProperties(CheckLatticeProperties, unittest.TestCase):
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.filename = os.path.join(self.temp_dir, 'test_file.cuds')
         self.addCleanup(self.cleanup)
         self.handle = tables.open_file(self.filename, mode='w')
-        ABCCheckLattice.setUp(self)
+        CheckLatticeProperties.setUp(self)
 
     def cleanup(self):
         if os.path.exists(self.filename):
@@ -48,59 +47,74 @@ class TestH5Lattice(ABCCheckLattice, unittest.TestCase):
         return set(CUBA)
 
     def test_initialization_from_existing_lattice_in_file(self):
-        """ Checks that H5Lattice constructed from Lattice with a
-        CustomRecord column description has correct attributes
-        """
         lattice = H5Lattice(self.group)
-        self.assertEqual(lattice.name, 'foo')
+        self.assertEqual(lattice.name, 'my_name')
         self.assertEqual(lattice.type, 'Cubic')
         assert_array_equal(lattice.base_vect, self.base_vect)
         self.assertItemsEqual(lattice.size, self.size)
         assert_array_equal(lattice.origin, self.origin)
 
-    def test_set_modify_data(self):
-        """ Check that data can be retrieved and is consistent. Check that
-        the internal data of the lattice cannot be modified outside the
-        lattice class
-        """
-        lattice = self.container_factory('test_lat', 'Cubic',
-                                         (1.0, 1.0, 1.0), (4, 3, 2),
-                                         (0, 0, 0))
-        org_data = DataContainer()
 
-        org_data[CUBA.VELOCITY] = (0, 0, 0)
+class TestH5LatticeNodeCoordinates(
+        CheckLatticeNodeCoordinates, unittest.TestCase):
 
-        lattice.data = org_data
-        ret_data = lattice.data
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.temp_dir, 'test_file.cuds')
+        self.addCleanup(self.cleanup)
+        self.handle = tables.open_file(self.filename, mode='w')
 
-        self.assertEqual(org_data, ret_data)
-        self.assertIsNot(org_data, ret_data)
+    def cleanup(self):
+        if os.path.exists(self.filename):
+            self.handle.close()
+        shutil.rmtree(self.temp_dir)
 
-        org_data = DataContainer()
+    def container_factory(self, name, type_, base_vect, size, origin):
+        self.group = self.handle.create_group(
+            self.handle.root, name)
+        return H5Lattice.create_new(
+            self.group, type_, base_vect, size, origin)
 
-        org_data[CUBA.VELOCITY] = (0, 0, 0)
+    def supported_cuba(self):
+        return set(CUBA)
 
-        lattice.data = org_data
-        mod_data = lattice.data
+    @unittest.skip('Hexagonal coordinates are not supported yet')
+    def test_get_coordinate_hexagonal(self):
+        pass
 
-        mod_data[CUBA.VELOCITY] = (1, 1, 1)
+class TestH5LatticeNodeOperations(
+        CheckLatticeNodeOperations, unittest.TestCase):
 
-        ret_data = lattice.data
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.temp_dir, 'test_file.cuds')
+        self.addCleanup(self.cleanup)
+        self.handle = tables.open_file(self.filename, mode='w')
+        CheckLatticeNodeOperations.setUp(self)
 
-        self.assertEqual(org_data, ret_data)
-        self.assertIsNot(org_data, ret_data)
+    def cleanup(self):
+        if os.path.exists(self.filename):
+            self.handle.close()
+        shutil.rmtree(self.temp_dir)
+
+    def container_factory(self, name, type_, base_vect, size, origin):
+        self.group = self.handle.create_group(
+            self.handle.root, name)
+        return H5Lattice.create_new(
+            self.group, type_, base_vect, size, origin)
+
+    def supported_cuba(self):
+        return set(CUBA)
 
 
-class TestFileLatticeCustom(ABCCheckLattice, unittest.TestCase):
-    """ Test H5Lattice using a custom record.
-    """
+class TestH5LatticeNodeCustomCoordinates(
+        CheckLatticeNodeCoordinates, unittest.TestCase):
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.filename = os.path.join(self.temp_dir, 'test_file.cuds')
         self.addCleanup(self.cleanup)
         self.handle = tables.open_file(self.filename, 'w')
-        ABCCheckLattice.setUp(self)
 
     def cleanup(self):
         if os.path.exists(self.filename):
@@ -116,16 +130,34 @@ class TestFileLatticeCustom(ABCCheckLattice, unittest.TestCase):
     def supported_cuba(self):
         return [CUBA.VELOCITY, CUBA.MATERIAL_ID, CUBA.DENSITY]
 
-    def test_initialization_from_existing_lattice_in_file(self):
-        """ Checks that H5Lattice constructed from Lattice with a
-        CustomRecord column description has correct attributes
-        """
-        lattice = H5Lattice(self.group)
-        self.assertEqual(lattice.name, 'foo')
-        self.assertEqual(lattice.type, 'Cubic')
-        assert_array_equal(lattice.base_vect, self.base_vect)
-        self.assertItemsEqual(lattice.size, self.size)
-        assert_array_equal(lattice.origin, self.origin)
+    @unittest.skip('Hexagonal coordinates are not supported yet')
+    def test_get_coordinate_hexagonal(self):
+        pass
+
+
+class TestH5LatticeCustomNodeOperations(
+        CheckLatticeNodeOperations, unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.temp_dir, 'test_file.cuds')
+        self.addCleanup(self.cleanup)
+        self.handle = tables.open_file(self.filename, 'w')
+        CheckLatticeNodeOperations.setUp(self)
+
+    def cleanup(self):
+        if os.path.exists(self.filename):
+            self.handle.close()
+        shutil.rmtree(self.temp_dir)
+
+    def container_factory(self, name, type_, base_vect, size, origin):
+        self.group = self.handle.create_group(
+            self.handle.root, name)
+        return H5Lattice.create_new(self.group, type_, base_vect, size,
+                                    origin, record=CustomRecord)
+
+    def supported_cuba(self):
+        return [CUBA.VELOCITY, CUBA.MATERIAL_ID, CUBA.DENSITY]
 
 
 if __name__ == '__main__':

--- a/simphony/io/tests/test_h5_lattice.py
+++ b/simphony/io/tests/test_h5_lattice.py
@@ -78,10 +78,6 @@ class TestH5LatticeNodeCoordinates(
     def supported_cuba(self):
         return set(CUBA)
 
-    @unittest.skip('Hexagonal coordinates are not supported yet')
-    def test_get_coordinate_hexagonal(self):
-        pass
-
 
 class TestH5LatticeNodeOperations(
         CheckLatticeNodeOperations, unittest.TestCase):
@@ -130,10 +126,6 @@ class TestH5LatticeNodeCustomCoordinates(
 
     def supported_cuba(self):
         return [CUBA.VELOCITY, CUBA.MATERIAL_ID, CUBA.DENSITY]
-
-    @unittest.skip('Hexagonal coordinates are not supported yet')
-    def test_get_coordinate_hexagonal(self):
-        pass
 
 
 class TestH5LatticeCustomNodeOperations(

--- a/simphony/testing/abc_check_lattice.py
+++ b/simphony/testing/abc_check_lattice.py
@@ -8,11 +8,11 @@ from simphony.testing.utils import (
     create_data_container, compare_data_containers, compare_lattice_nodes)
 from simphony.cuds.lattice import (
     LatticeNode, make_square_lattice, make_rectangular_lattice,
-    make_orthorombicp_lattice)
+    make_orthorombicp_lattice, make_hexagonal_lattice, make_cubic_lattice)
 from simphony.core.data_container import DataContainer
 
 
-class ABCCheckLattice(object):
+class CheckLatticeNodeOperations(object):
 
     __metaclass__ = abc.ABCMeta
 
@@ -22,7 +22,7 @@ class ABCCheckLattice(object):
         self.addTypeEqualityFunc(
             LatticeNode, partial(compare_lattice_nodes, testcase=self))
         self.size = (5, 10, 15)
-        self.base_vect = (0.1, 0.2, 0.3)
+        self.base_vect = (0.2, 0.2, 0.2)
         self.origin = (-2.0, 0.0, 1.0)
         self.container = self.container_factory(
             'foo', 'Cubic', self.base_vect, self.size, self.origin)
@@ -141,16 +141,39 @@ class ABCCheckLattice(object):
         # Check that `new_node` is not the same instance as `node`
         self.assertIsNot(new_node, node)
 
+
+class CheckLatticeNodeCoordinates(object):
+
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def container_factory(self, name, type_, base_vect, size, origin):
+        """ Create and return a lattice.
+        """
+
+    @abc.abstractmethod
+    def supported_cuba(self):
+        """ Return a list of CUBA keys to use for restricted containers.
+
+        """
+
     def test_get_coordinate_cubic(self):
-        container = self.container
-        xspace, yspace, zspace = self.base_vect
-        x, y, z = numpy.meshgrid(
-            range(self.size[0]), range(self.size[1]), range(self.size[2]))
+        default = make_cubic_lattice(
+            'Lattice3', 0.2, (5, 10, 15), (-2.0, 0.0, 1.0))
+        container = self.container_factory(
+            default.name,
+            default.type,
+            default.base_vect,
+            default.size,
+            default.origin)
+        xspace, yspace, zspace = default.base_vect
+        x, y, z = numpy.meshgrid(range(
+            default.size[0]), range(default.size[1]), range(default.size[2]))
         indexes = zip(x.flat, y.flat, z.flat)
         expected = zip(
-            x.ravel() * xspace + self.origin[0],
-            y.ravel() * yspace + self.origin[1],
-            z.ravel() * zspace + self.origin[2])
+            x.ravel() * xspace + default.origin[0],
+            y.ravel() * yspace + default.origin[1],
+            z.ravel() * zspace + default.origin[2])
 
         for i, index in enumerate(indexes):
             assert_array_equal(container.get_coordinate(index), expected[i])
@@ -208,6 +231,7 @@ class ABCCheckLattice(object):
             default.size,
             default.origin)
         xspace, yspace, zspace = default.base_vect
+
         x, y, z = numpy.meshgrid(
             range(default.size[0]),
             range(default.size[1]),
@@ -221,12 +245,56 @@ class ABCCheckLattice(object):
         for i, index in enumerate(indexes):
             assert_array_equal(container.get_coordinate(index), expected[i])
 
+    def test_get_coordinate_hexagonal(self):
+        default = make_hexagonal_lattice(
+            'Lattice4', (0.5, 0.54, 0.58), (15, 25, 35), (7, 9, 8))
+        container = self.container_factory(
+            default.name,
+            default.type,
+            default.base_vect,
+            default.size,
+            default.origin)
+        xspace, yspace, zspace = default.base_vect
+
+        for node in container.iter_nodes():
+            position = (
+                node.index[0] * xspace + 0.5 * xspace * (node.index[1] % 2),
+                node.index[1] * yspace,
+                container.origin[2])
+            assert_array_equal(container.get_coordinates[node.index], position)
+
+
+class CheckLatticeProperties(object):
+
+    __metaclass__ = abc.ABCMeta
+
+    def setUp(self):
+        self.addTypeEqualityFunc(
+            DataContainer, partial(compare_data_containers, testcase=self))
+        self.addTypeEqualityFunc(
+            LatticeNode, partial(compare_lattice_nodes, testcase=self))
+        self.size = (5, 10, 15)
+        self.base_vect = (0.2, 0.2, 0.2)
+        self.origin = (-2.0, 0.0, 1.0)
+        self.container = self.container_factory(
+            'my_name', 'Cubic', self.base_vect, self.size, self.origin)
+
+    @abc.abstractmethod
+    def container_factory(self, name, type_, base_vect, size, origin):
+        """ Create and return a lattice.
+        """
+
+    @abc.abstractmethod
+    def supported_cuba(self):
+        """ Return a list of CUBA keys to use for restricted containers.
+        """
+
     def test_lattice_properties(self):
         container = self.container
 
         # check values
         self.assertEqual(container.type, 'Cubic')
-        self.assertEqual(container.name, 'foo')
+        self.assertEqual(container.name, 'my_name')
         assert_array_equal(container.size, self.size)
         assert_array_equal(container.origin, self.origin)
         assert_array_equal(container.base_vect, self.base_vect)
@@ -244,6 +312,51 @@ class ABCCheckLattice(object):
         with self.assertRaises(AttributeError):
             container.base_vect = self.base_vect
 
-        # check read-write
-        container.name = 'boo'
-        self.assertEqual(container.name, 'boo')
+    def test_container_name(self):
+        # given/when
+        container = self.container
+
+        # then
+        self.assertEqual(container.name, 'my_name')
+
+    def test_container_name_update(self):
+        # given
+        container = self.container
+
+        # when
+        container.name = 'new'
+
+        # then
+        self.assertEqual(container.name, 'new')
+
+    def test_container_data(self):
+        # when
+        container = self.container
+
+        # then
+        self.assertEqual(container.data, DataContainer())
+
+    def test_container_data_update(self):
+        # given
+        container = self.container
+        data = create_data_container(restrict=self.supported_cuba())
+
+        # when
+        container.data = data
+
+        # then
+        self.assertEqual(container.data, data)
+        self.assertIsNot(container.data, data)
+
+    def test_container_data_update_with_unsupported_cuba(self):
+        # given
+        container = self.container
+        data = create_data_container()
+        expected_data = create_data_container(restrict=self.supported_cuba())
+
+        # when
+        container.data = data
+
+        # then
+        self.assertEqual(container.data, expected_data)
+        self.assertIsNot(container.data, expected_data)

--- a/simphony/testing/abc_check_lattice.py
+++ b/simphony/testing/abc_check_lattice.py
@@ -25,7 +25,7 @@ class CheckLatticeNodeOperations(object):
         self.base_vect = (0.2, 0.2, 0.2)
         self.origin = (-2.0, 0.0, 1.0)
         self.container = self.container_factory(
-            'foo', 'Cubic', self.base_vect, self.size, self.origin)
+            'my_name', 'Cubic', self.base_vect, self.size, self.origin)
 
     @abc.abstractmethod
     def container_factory(self, name, type_, base_vect, size, origin):

--- a/simphony/testing/abc_check_lattice.py
+++ b/simphony/testing/abc_check_lattice.py
@@ -256,11 +256,12 @@ class CheckLatticeNodeCoordinates(object):
         xspace, yspace, zspace = default.base_vect
 
         for node in container.iter_nodes():
+            index = node.index
             position = (
-                node.index[0] * xspace + 0.5 * xspace * (node.index[1] % 2),
-                node.index[1] * yspace,
+                index[0] * xspace + 0.5 * xspace * index[1],
+                index[1] * yspace,
                 container.origin[2])
-            assert_array_equal(container.get_coordinates[node.index], position)
+            assert_array_equal(container.get_coordinate(index), position)
 
 
 class CheckLatticeProperties(object):

--- a/simphony/testing/abc_check_lattice.py
+++ b/simphony/testing/abc_check_lattice.py
@@ -246,8 +246,7 @@ class CheckLatticeNodeCoordinates(object):
             assert_array_equal(container.get_coordinate(index), expected[i])
 
     def test_get_coordinate_hexagonal(self):
-        default = make_hexagonal_lattice(
-            'Lattice4', (0.5, 0.54, 0.58), (15, 25, 35), (7, 9, 8))
+        default = make_hexagonal_lattice('Lattice4', 0.1, (5, 4))
         container = self.container_factory(
             default.name,
             default.type,


### PR DESCRIPTION
This PR updates the Lattice testing templates.

in more detail:

- The templates are split into separate classes based on what functionality they are checking
- A small error in the intial `base_vect` value used in some tests has been corrected. We where passing variable spacing when it should have been all the same.
- A separate test cases has been created for the Lattice factories
- A provisional check method for the node coordinates on a Hexagonal lattice is provided 

