### PR TITLE
Add version information to CUDS HDF5 file

### DIFF
--- a/doc/source/uml/h5cuds.txt
+++ b/doc/source/uml/h5cuds.txt
@@ -4,7 +4,8 @@ class H5CUDS as "H5CUDS(Group)" {
    particle : Group = Particle
    mesh : Group = Bond
    lattice : Group = Lattice
-
+  -- Node Attributes --
+  cuds_version: int
 }
 
 class Particle as "Particle(Group)" {

--- a/doc/source/uml/h5cuds.txt
+++ b/doc/source/uml/h5cuds.txt
@@ -4,13 +4,13 @@ class H5CUDS as "H5CUDS(Group)" {
    particle : Group = Particle
    mesh : Group = Bond
    lattice : Group = Lattice
-  -- Node Attributes --
-  cuds_version: int
+   -- Node Attributes --
+   cuds_version: int
 }
 
 class Particle as "Particle(Group)" {
    _v_name : string = "particle"
-   children of type H5Partilces
+   children of type H5Particles
 }
 
 class Mesh as "Mesh(Group)" {

--- a/doc/source/uml/h5lattice.txt
+++ b/doc/source/uml/h5lattice.txt
@@ -12,6 +12,7 @@ class H5Lattice as "H5Lattice(Group)" {
   base_vect : float[3]
   size : int[3]
   origin: float[3]
+  cuds_version: int
 }
 
 class Nodes as "Nodes(Table)" {

--- a/doc/source/uml/h5mesh.txt
+++ b/doc/source/uml/h5mesh.txt
@@ -12,6 +12,8 @@ class Mesh as "H5Mesh(Group)" {
   cells : Table = Cells
   item_data : Table = Data
   data : Table = ContainerData
+  -- Node Attributes --
+  cuds_version: int
 }
 
 class Points as "Points(Table)" {

--- a/doc/source/uml/h5particles.txt
+++ b/doc/source/uml/h5particles.txt
@@ -9,6 +9,8 @@ class H5Particles as "H5Particles(Group)" {
    particles : Group = Particles
    bonds : Group = Bonds
    data : Table = ContainerData
+   -- Node Attributes --
+   cuds_version: int
 }
 
 class Particles as "Particles(Group)" {

--- a/simphony/io/h5_cuds.py
+++ b/simphony/io/h5_cuds.py
@@ -4,7 +4,7 @@ from simphony.io.h5_particles import H5Particles
 from simphony.io.h5_mesh import H5Mesh
 from simphony.io.h5_lattice import H5Lattice
 
-_file_version = 1
+H5_FILE_VERSION = 1
 
 
 class H5CUDS(object):
@@ -65,10 +65,10 @@ class H5CUDS(object):
 
         if handle.list_nodes("/"):
             if not ("cuds_version" in handle.root._v_attrs
-                    and handle.root._v_attrs.cuds_version == _file_version):
+                    and handle.root._v_attrs.cuds_version == H5_FILE_VERSION):
                 raise ValueError("File version is incompatible")
         else:
-            handle.root._v_attrs.cuds_version = _file_version
+            handle.root._v_attrs.cuds_version = H5_FILE_VERSION
             for group in ('particle', 'lattice', 'mesh'):
                 if "/" + group not in handle:
                     handle.create_group('/', group, group)

--- a/simphony/io/h5_cuds.py
+++ b/simphony/io/h5_cuds.py
@@ -17,7 +17,7 @@ class H5CUDS(object):
 
         Parameters
         ----------
-        file : table.file
+        handle : table.file
             file to be used
 
         """

--- a/simphony/io/h5_lattice.py
+++ b/simphony/io/h5_lattice.py
@@ -7,6 +7,9 @@ from simphony.core.data_container import DataContainer
 import numpy as np
 
 
+LATTICE_CUDS_VERSION = 1
+
+
 class H5Lattice(ABCLattice):
     """ H5Lattice object to use H5CUDS lattices.
 
@@ -21,6 +24,9 @@ class H5Lattice(ABCLattice):
             for lattice and data are located
 
         """
+        if group._v_attrs.cuds_version != LATTICE_CUDS_VERSION:
+            raise ValueError("Lattice file layout has an incompatible version")
+
         self._group = group
         self._type = group.lattice.attrs.type
         self._base_vect = group.lattice.attrs.base_vect
@@ -51,6 +57,8 @@ class H5Lattice(ABCLattice):
             A class that describes column types for PyTables table.
 
         """
+        group._v_attrs.cuds_version = LATTICE_CUDS_VERSION
+
         # If record not specified use NoUIDRecord in table initialization
         lattice = IndexedDataContainerTable(group, 'lattice',
                                             record if record is not None

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -766,25 +766,25 @@ class H5Mesh(object):
         return uuid.uuid4()
 
     def _create_points_table(self):
-        """ Generates the table to sotre points """
+        """ Generates the table to store points """
 
         self._file.create_table(
             self._group, "points", _PointDescriptor)
 
     def _create_edges_table(self):
-        """ Generates the table to sotre edges """
+        """ Generates the table to store edges """
 
         self._file.create_table(
             self._group, "edges", _EdgeDescriptor)
 
     def _create_faces_table(self):
-        """ Generates the table to sotre faces """
+        """ Generates the table to store faces """
 
         self._file.create_table(
             self._group, "faces", _FaceDescriptor)
 
     def _create_cells_table(self):
-        """ Generates the table to sotre cells """
+        """ Generates the table to store cells """
 
         self._file.create_table(
             self._group, "cells", _CellDescriptor)

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -21,6 +21,8 @@ MAX_POINTS_IN_EDGE = 2
 MAX_POINTS_IN_FACE = 4
 MAX_POINTS_IN_CELL = 8
 
+MESH_CUDS_VERSION = 1
+
 
 class _PointDescriptor(tables.IsDescription):
     """ Descriptor for storing Point information
@@ -121,6 +123,13 @@ class H5Mesh(object):
     """
 
     def __init__(self, group, meshFile):
+
+        if not ("cuds_version" in group._v_attrs):
+            group._v_attrs.cuds_version = MESH_CUDS_VERSION
+        else:
+            if group._v_attrs.cuds_version != MESH_CUDS_VERSION:
+                raise ValueError(
+                    "Mesh file layout has an incompatible version")
 
         self._file = meshFile
         self._group = group

--- a/simphony/io/h5_particles.py
+++ b/simphony/io/h5_particles.py
@@ -13,6 +13,8 @@ from simphony.io.indexed_data_container_table import IndexedDataContainerTable
 
 MAX_NUMBER_PARTICLES_IN_BOND = 20
 
+PARTICLES_CUDS_VERSION = 1
+
 
 class _ParticleDescription(tables.IsDescription):
     uid = tables.StringCol(32, pos=0)
@@ -121,6 +123,13 @@ class H5Particles(ABCParticles):
 
     """
     def __init__(self, group):
+        if not ("cuds_version" in group._v_attrs):
+            group._v_attrs.cuds_version = PARTICLES_CUDS_VERSION
+        else:
+            if group._v_attrs.cuds_version != PARTICLES_CUDS_VERSION:
+                raise ValueError(
+                    "Particles file layout has an incompatible version")
+
         self._group = group
         self._data = IndexedDataContainerTable(group, 'data')
         self._particles = H5ParticleItems(group, 'particles')

--- a/simphony/io/tests/test_h5_cuds.py
+++ b/simphony/io/tests/test_h5_cuds.py
@@ -486,7 +486,7 @@ class TestH5CUDSVersions(unittest.TestCase):
             h5file.root._v_attrs.cuds_version = -1
 
         with self.assertRaises(ValueError):
-            H5CUDS.open(self.filename)
+            H5CUDS.open(self.existing_filename)
 
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/io/tests/test_h5_cuds.py
+++ b/simphony/io/tests/test_h5_cuds.py
@@ -5,6 +5,8 @@ import shutil
 import tempfile
 import uuid
 
+import tables
+
 from simphony.core.cuba import CUBA
 from simphony.core.data_container import DataContainer
 from simphony.cuds.particles import Particle, Particles
@@ -460,6 +462,31 @@ class TestH5CUDS(unittest.TestCase):
             # and we should be able to use the no-longer used
             # "foo" name when adding another lattice
             m = handle.add_lattice(lat)
+
+
+class TestH5CUDSVersions(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.existing_filename = os.path.join(self.temp_dir, 'test.cuds')
+        handle = H5CUDS.open(self.existing_filename)
+        handle.close()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_version(self):
+        with closing(tables.open_file(
+                     self.existing_filename, mode="r")) as h5file:
+            self.assertTrue(isinstance(h5file.root._v_attrs.cuds_version, int))
+
+    def test_incorrect_version(self):
+        with closing(tables.open_file(
+                     self.existing_filename, mode="a")) as h5file:
+            h5file.root._v_attrs.cuds_version = -1
+
+        with self.assertRaises(ValueError):
+            H5CUDS.open(self.filename)
 
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/io/tests/test_h5_mesh.py
+++ b/simphony/io/tests/test_h5_mesh.py
@@ -154,5 +154,35 @@ class TestH5MeshStoredLayout(unittest.TestCase):
         self.assertIsInstance(group.item_data, tables.Table)
 
 
+class TestH5MeshVersions(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_version(self):
+        filename = os.path.join(self.temp_dir, 'test_file.cuds')
+        group_name = "dummy_component_name"
+        with tables.open_file(filename, 'w') as handle:
+            group = handle.create_group(handle.root, group_name)
+
+            # given/when
+            H5Mesh(group, handle)
+
+            # then
+            self.assertTrue(isinstance(group._v_attrs.cuds_version, int))
+
+        # when
+        with tables.open_file(filename, 'a') as handle:
+            handle.get_node("/" + group_name)._v_attrs.cuds_version = -1
+
+        # then
+        with tables.open_file(filename, 'a') as handle:
+            with self.assertRaises(ValueError):
+                H5Mesh(handle.get_node("/" + group_name), handle)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/simphony/io/tests/test_h5_particles.py
+++ b/simphony/io/tests/test_h5_particles.py
@@ -3,8 +3,11 @@ import tempfile
 import shutil
 import unittest
 
+import tables
+
 from simphony.cuds.particles import Particles
 from simphony.io.h5_cuds import H5CUDS
+from simphony.io.h5_particles import H5Particles
 from simphony.core.cuba import CUBA
 from simphony.testing.abc_check_particles import (
     ContainerManipulatingBondsCheck, ContainerAddParticlesCheck,
@@ -100,6 +103,36 @@ class TestH5ContainerManipulatingBonds(
         if os.path.exists(self.filename):
             self.handle.close()
         shutil.rmtree(self.temp_dir)
+
+
+class TestH5ParticlesVersions(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_version(self):
+        filename = os.path.join(self.temp_dir, 'test_file.cuds')
+        group_name = "dummy_component_name"
+        with tables.open_file(filename, 'w') as handle:
+            group = handle.create_group(handle.root, group_name)
+
+            # given/when
+            H5Particles(group)
+
+            # then
+            self.assertTrue(isinstance(group._v_attrs.cuds_version, int))
+
+        # when
+        with tables.open_file(filename, 'a') as handle:
+            handle.get_node("/" + group_name)._v_attrs.cuds_version = -1
+
+        # then
+        with tables.open_file(filename, 'a') as handle:
+            with self.assertRaises(ValueError):
+                H5Particles(handle.get_node("/" + group_name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses #156 by adding version information to the CUDS HDF5 file.  Specifically, a 'cuds_version' was added as an HDF5-attribute of type `int` to:
 *  *"1. Top level version of the main group (i.e. root) where the container types are grouped. This is the expected layout of the file as defined in H5CUDS."*
 *  *"2. The CUDS container hdf5 layout version separate for each CUDS container. "*

Only a single individual version (the latest) is supported and an exception is thrown when reading files containing a different version.

See discussions in issue #156 for more detail on versioning. In general, when a developer changes the top level layout (i.e. root), then the top level 'cuds-version' should be incremented for that release of SimPhoNy.  When a developer changes the layout of the CUDS container components, that's  'cuds_version' should be incremented for that release of SimPhony and the top-level version (i.e. root) should also be incremented.   

This PR doesn't update the UML images (see #179) 