### PR TITLE
Setup appveyor runs

### DIFF
--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -1,0 +1,14 @@
+"%sdkverpath%" -q -version:"%sdkver%"
+call setenv /x64
+
+rem install python packages
+pip install --cache-dir $Env:whell_cache numexpr
+pip install --cache-dir $Env:whell_cache -r dev_requirements
+
+rem install simphony-common
+python setup.py develop
+if %errorlevel% neq 0 exit /b %errorlevel%
+cd examples/plugin
+python setup.py develop
+if %errorlevel% neq 0 exit /b %errorlevel%
+cd ..

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -2,8 +2,8 @@
 call setenv /x64
 
 rem install python packages
-pip install --cache-dir $Env:whell_cache numexpr
-pip install --cache-dir $Env:whell_cache -r dev_requirements
+pip install --cache-dir "%whell_cache%" numexpr
+pip install --cache-dir "%Env:whell_cache%" -r dev_requirements.txt
 
 rem install simphony-common
 python setup.py develop

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -15,7 +15,7 @@ pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
 pip install mock
 pip install coverage
-pip install flake8'
+pip install flake8
 
 rem install simphony-common
 python setup.py develop

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -13,7 +13,7 @@ pip install pyyaml>=3.11
 pip install sphinx>1.2.3
 pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
-pip install mock
+pip install mock==1.0.1
 pip install coverage
 pip install flake8
 

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -10,7 +10,7 @@ pip install enum34>=1.0.4
 pip install stevedore>=1.2.0
 pip install click>=3.3
 pip install pyyaml>=3.11
-pip install sphinx>=1.2.3
+pip install sphinx>1.2.3
 pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
 pip install mock

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -2,8 +2,8 @@
 call setenv /x64
 
 rem install python packages
-pip install --cache-dir "%whell_cache%" numexpr
-pip install --cache-dir "%Env:whell_cache%" -r dev_requirements.txt
+pip install --cache-dir "%wheel_cache%" numexpr
+pip install --cache-dir "%wheel_cache%" -r dev_requirements.txt
 
 rem install simphony-common
 python setup.py develop

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -6,16 +6,16 @@ pip install numpy
 rem builds currently fail
 rem pip install numexpr
 rem pip install tables >= 3.1.1
-pip install 'enum34>=1.0.4'
-pip install 'stevedore>=1.2.0'
-pip install 'click>=3.3'
-pip install 'pyyaml>=3.11'
-pip install 'sphinx>=1.2.3'
-pip install 'sphinxcontrib-napoleon>=0.2.10'
-pip install 'tabulate>=0.7.4'
-pip install 'mock'
-pip install 'coverage'
-pip install 'flake8'
+pip install enum34>=1.0.4
+pip install stevedore>=1.2.0
+pip install click>=3.3
+pip install pyyaml>=3.11
+pip install sphinx>=1.2.3
+pip install sphinxcontrib-napoleon>=0.2.10
+pip install tabulate>=0.7.4
+pip install mock
+pip install coverage
+pip install flake8'
 
 rem install simphony-common
 python setup.py develop

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -2,6 +2,7 @@
 call setenv /x64
 
 rem install python packages
+pip install numpy
 pip install numexpr
 pip install -r dev_requirements.txt
 

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -2,8 +2,8 @@
 call setenv /x64
 
 rem install python packages
-pip install --cache-dir "%wheel_cache%" numexpr
-pip install --cache-dir "%wheel_cache%" -r dev_requirements.txt
+pip install numexpr
+pip install -r dev_requirements.txt
 
 rem install simphony-common
 python setup.py develop

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -3,8 +3,19 @@ call setenv /x64
 
 rem install python packages
 pip install numpy
-pip install numexpr
-pip install -r dev_requirements.txt
+rem builds currently fail
+rem pip install numexpr
+rem pip install tables >= 3.1.1
+pip install 'enum34>=1.0.4'
+pip install 'stevedore>=1.2.0'
+pip install 'click>=3.3'
+pip install 'pyyaml>=3.11'
+pip install 'sphinx>=1.2.3'
+pip install 'sphinxcontrib-napoleon>=0.2.10'
+pip install 'tabulate>=0.7.4'
+pip install 'mock'
+pip install 'coverage'
+pip install 'flake8'
 
 rem install simphony-common
 python setup.py develop

--- a/appveyor-test.cmd
+++ b/appveyor-test.cmd
@@ -5,6 +5,6 @@ flake8 .
 if %errorlevel% neq 0 exit /b %errorlevel%
 coverage run -m unittest discover -p test*
 if %errorlevel% neq 0 exit /b %errorlevel%
-python setup.py build_shpinx
+python setup.py build_sphinx
 if %errorlevel% neq 0 exit /b %errorlevel%
 coverage report

--- a/appveyor-test.cmd
+++ b/appveyor-test.cmd
@@ -1,0 +1,10 @@
+"%sdkverpath%" -q -version:"%sdkver%"
+call setenv /x64
+
+flake8 .
+if %errorlevel% neq 0 exit /b %errorlevel%
+coverage run -m unittest discover -p test*
+if %errorlevel% neq 0 exit /b %errorlevel%
+python setup.py build_shpinx
+if %errorlevel% neq 0 exit /b %errorlevel%
+coverage report

--- a/appveyor-test.cmd
+++ b/appveyor-test.cmd
@@ -3,7 +3,7 @@ call setenv /x64
 
 flake8 .
 if %errorlevel% neq 0 exit /b %errorlevel%
-coverage run -m unittest discover -p test*
+coverage run -m unittest discover -v -p test*
 if %errorlevel% neq 0 exit /b %errorlevel%
 python setup.py build_sphinx
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ init:
   - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
 install:
-  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'c:/get-pip.py')
-  - ps: python c:/get-pip.py
+  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', $Env:TEMP + '/get-pip.py')
+  - ps: python $Env:TEMP + '/get-pip.py'
   - ps: pip --version
   - cmd /v:on /e:on /c ".\appveyor-install.cmd"
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,6 @@ environment:
     - python: "C:/Python27-x64"
       sdkver: "v7.0"
 
-    - python: "C:/Python33-x64"
-      sdkver: "v7.1"
-
-    - python: "C:/Python34-x64"
-      sdkver: "v7.1"
-
 cache:
   - c:\wheel_cache
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+build: false
+shallow_clone: true
+environment:
+
+  global:
+    distutils_use_sdk: 1
+    wheel_cache: "C:\wheels"
+
+  matrix:
+    - python: "C:/Python27-x64"
+      sdkver: "v7.0"
+
+    - python: "C:/Python33-x64"
+      sdkver: "v7.1"
+
+    - python: "C:/Python34-x64"
+      sdkver: "v7.1"
+
+cache:
+  - c:\wheel_cache
+
+init:
+  - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
+  - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
+  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
+install:
+  - ps: if ((Test-Path $Env:wheel_cache) -eq 0) { mkdir $Env:wheel_cache }
+  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'c:/get-pip.py')
+  - ps: python c:/get-pip.py
+  - ps: pip --version
+  - cmd /v:on /e:on /c ".\appveyor-install.cmd"
+test_script:
+  - cmd /v:on /e:on /c ".\appveyor-test.cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,4 +24,4 @@ install:
   - ps: pip --version
   - cmd /v:on /e:on /c ".\appveyor-install.cmd"
 test_script:
-  - cmd /v:on /e:on /c ".\appveyor-test.cmd"
+  #- cmd /v:on /e:on /c ".\appveyor-test.cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
 
   global:
     distutils_use_sdk: 1
-    wheel_cache: "C:/wheels"
 
   matrix:
     - python: "C:/Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,4 +22,4 @@ install:
   - ps: pip --version
   - cmd /v:on /e:on /c ".\appveyor-install.cmd"
 test_script:
-  #- cmd /v:on /e:on /c ".\appveyor-test.cmd"
+  - cmd /v:on /e:on /c ".\appveyor-test.cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,13 @@ environment:
       sdkver: "v7.0"
 
 cache:
-  - c:\wheel_cache
+  - %localappdata%\pip\cache
 
 init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
   - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
 install:
-  - ps: if ((Test-Path $Env:wheel_cache) -eq 0) { mkdir $Env:wheel_cache }
   - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'c:/get-pip.py')
   - ps: python c:/get-pip.py
   - ps: pip --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       sdkver: "v7.0"
 
 cache:
-  - %localappdata%\pip\cache
+  - '%localappdata%\pip\cache'
 
 init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
   global:
     distutils_use_sdk: 1
-    wheel_cache: "C:\wheels"
+    wheel_cache: "C:/wheels"
 
   matrix:
     - python: "C:/Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,10 @@ init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
   - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
+  - ps: $Env:pip_bootstrap = $Env:temp + "\get-pip.py"
 install:
-  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', $Env:TEMP + '/get-pip.py')
-  - ps: python $Env:TEMP + '/get-pip.py'
+  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', $Env:pip_bootstrap)
+  - ps: python $Env:pip_bootstrap
   - ps: pip --version
   - cmd /v:on /e:on /c ".\appveyor-install.cmd"
 test_script:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,7 +6,7 @@ pyyaml >= 3.11
 sphinx >= 1.2.3
 sphinxcontrib-napoleon >= 0.2.10
 tabulate >= 0.7.4
-mock
+mock==1.0.1
 coverage
 flake8
 numpy >= 1.4.1


### PR DESCRIPTION
This PR adds setup files to run tests on appveyor (windows). Currently the hdf5 based tests are skipped because building the hdf5 package for python 2.7 is a little tricky. 