### PR TITLE
Fix warnings when building documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,7 @@ To support the HDF5 based native IO:
 
 To support the documentation built you need the following packages:
 
-- sphinx >= 1.3
-- sphinxcontrib-napoleon >= 0.2.10
+- sphinx >= 1.3.1
 - mock
 
 .. note::

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ To support the HDF5 based native IO:
 
 To support the documentation built you need the following packages:
 
-- sphinx >= 1.2.3
+- sphinx >= 1.3
 - sphinxcontrib-napoleon >= 0.2.10
 - mock
 

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -10,7 +10,7 @@ pip install enum34>=1.0.4
 pip install stevedore>=1.2.0
 pip install click>=3.3
 pip install pyyaml>=3.11
-pip install sphinx>1.3
+pip install sphinx>=1.3
 pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
 pip install mock==1.0.1

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -10,7 +10,7 @@ pip install enum34>=1.0.4
 pip install stevedore>=1.2.0
 pip install click>=3.3
 pip install pyyaml>=3.11
-pip install sphinx>1.2.3
+pip install sphinx>1.3
 pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
 pip install mock==1.0.1

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -10,7 +10,7 @@ pip install enum34>=1.0.4
 pip install stevedore>=1.2.0
 pip install click>=3.3
 pip install pyyaml>=3.11
-pip install sphinx>=1.3
+pip install sphinx>=1.3.1
 pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
 pip install mock==1.0.1

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -11,7 +11,6 @@ pip install stevedore>=1.2.0
 pip install click>=3.3
 pip install pyyaml>=3.11
 pip install sphinx>=1.3.1
-pip install sphinxcontrib-napoleon>=0.2.10
 pip install tabulate>=0.7.4
 pip install mock==1.0.1
 pip install coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       sdkver: "v7.0"
 
 cache:
-  - '%localappdata%\pip\cache' -> appveyor-install.cmd
+  - '%localappdata%\pip\cache -> appveyor-install.cmd'
 
 init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       sdkver: "v7.0"
 
 cache:
-  - '%localappdata%\pip\cache'
+  - '%localappdata%\pip\cache' -> appveyor-install.cmd
 
 init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@ tables >= 3.1.1
 stevedore >= 1.2.0
 click >= 3.3
 pyyaml >= 3.11
-sphinx >= 1.2.3
+sphinx >= 1.3
 sphinxcontrib-napoleon >= 0.2.10
 tabulate >= 0.7.4
 mock==1.0.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@ tables >= 3.1.1
 stevedore >= 1.2.0
 click >= 3.3
 pyyaml >= 3.11
-sphinx >= 1.3
+sphinx >= 1.3.1
 sphinxcontrib-napoleon >= 0.2.10
 tabulate >= 0.7.4
 mock==1.0.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,6 @@ stevedore >= 1.2.0
 click >= 3.3
 pyyaml >= 3.11
 sphinx >= 1.3.1
-sphinxcontrib-napoleon >= 0.2.10
 tabulate >= 0.7.4
 mock==1.0.1
 coverage

--- a/doc/source/api/cuds.rst
+++ b/doc/source/api/cuds.rst
@@ -11,9 +11,9 @@ Abstract CUDS interfaces
 
 .. autosummary::
 
-   ~abstractmesh.ABCMesh
-   ~abstractparticles.ABCParticles
-   ~abstractlattice.ABCLattice
+   ~abc_mesh.ABCMesh
+   ~abc_particles.ABCParticles
+   ~abc_lattice.ABCLattice
 
 .. rubric:: Description
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -132,7 +132,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -62,7 +62,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 1.2.3
+sphinx >= 1.3
 sphinxcontrib-napoleon >= 0.2.10
 enum34 >= 1.0.4
 stevedore >= 1.2.0

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,4 @@
-sphinx >= 1.3
-sphinxcontrib-napoleon >= 0.2.10
+sphinx >= 1.3.1
 enum34 >= 1.0.4
 stevedore >= 1.2.0
 mock

--- a/simphony/cuds/abc_particles.py
+++ b/simphony/cuds/abc_particles.py
@@ -166,7 +166,7 @@ class ABCParticles(object):
         Raises
         ------
         KeyError :
-           when the particle is not in the container.
+            when the particle is not in the container.
 
         Returns
         -------
@@ -187,7 +187,7 @@ class ABCParticles(object):
         Raises
         ------
         KeyError :
-           when the bond is not in the container.
+            when the bond is not in the container.
 
         Returns
         -------
@@ -205,14 +205,13 @@ class ABCParticles(object):
 
         Parameters
         ----------
-        uid : uuid.UUID
-            the uid of the particle to be removed.
+        uids : iterable of uuid.UUID
+            the uids of the particles to be removed.
 
         Raises
         ------
         KeyError :
-           If any particle doesn't exist.
-
+            If any particle doesn't exist.
 
         Examples
         --------

--- a/simphony/cuds/abc_particles.py
+++ b/simphony/cuds/abc_particles.py
@@ -232,8 +232,13 @@ class ABCParticles(object):
 
         Parameters
         ----------
-        uids : uuid.UUID
-            the uid of the bond to be removed.
+        uids : iterable of uuid.UUID
+            the uids of the bond to be removed.
+
+        Raises
+        ------
+        KeyError :
+            If any bond doesn't exist.
 
         Examples
         --------

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -256,14 +256,13 @@ class Particles(ABCParticles):
 
         Parameters
         ----------
-        uid : uuid.UUID
-            the uid of the particle to be removed.
+        uids : iterable of uuid.UUID
+            the uids of the particles to be removed.
 
         Raises
         ------
         KeyError :
            If any particle doesn't exist.
-
 
         Examples
         --------

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -289,8 +289,8 @@ class Particles(ABCParticles):
 
         Parameters
         ----------
-        uids : uuid.UUID
-            the uid of the bond to be removed.
+        uids : iterable of uuid.UUID
+            the uids of the bonds to be removed.
 
         Examples
         --------


### PR DESCRIPTION
This PR fixes #213 by:
- fixing some ABC module names in documentation
- increases sphinx version to >=1.3 and use the 'classic' theme
- updated some docstrs