### PR TITLE
Extend tests to allow certain number of datasets

### DIFF
--- a/simphony/testing/abc_check_engine.py
+++ b/simphony/testing/abc_check_engine.py
@@ -215,6 +215,7 @@ class CheckEngine(object):
         # we should be able to access using the new "bar" name
         ds_bar = engine.get_dataset("bar")
         self.assertEqual(ds_bar.name, "bar")
+        engine.remove_dataset("bar")
 
         # and we should be able to use the no-longer used
         # "foo" name when adding another dataset

--- a/simphony/testing/abc_check_engine.py
+++ b/simphony/testing/abc_check_engine.py
@@ -215,7 +215,8 @@ class CheckEngine(object):
         # we should be able to access using the new "bar" name
         ds_bar = engine.get_dataset("bar")
         self.assertEqual(ds_bar.name, "bar")
-        engine.remove_dataset("bar")
+        if self.number_datasets_used_in_testing < 2:
+            engine.remove_dataset("bar")
 
         # and we should be able to use the no-longer used
         # "foo" name when adding another dataset

--- a/simphony/testing/abc_check_engine.py
+++ b/simphony/testing/abc_check_engine.py
@@ -15,9 +15,10 @@ class CheckEngine(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def setUp(self):
+    def setUp(self, number_datasets_used_in_testing):
         self.maxDiff = None
         self.items = self.create_dataset_items()
+        self.number_datasets_used_in_testing = number_datasets_used_in_testing
 
     @abc.abstractmethod
     def engine_factory(self):
@@ -129,7 +130,7 @@ class CheckEngine(object):
         # add a few empty datasets
         ds_names = []
 
-        for i in xrange(5):
+        for i in xrange(self.number_datasets_used_in_testing):
             name = "test_{}".format(i)
             ds_names.append(name)
             engine.add_dataset(self.create_dataset(name=name))
@@ -144,7 +145,7 @@ class CheckEngine(object):
         # add a few empty datasets
         ds_names = []
 
-        for i in xrange(5):
+        for i in xrange(self.number_datasets_used_in_testing):
             name = "test_{}".format(i)
             ds_names.append(name)
             engine.add_dataset(self.create_dataset(name=name))
@@ -155,7 +156,9 @@ class CheckEngine(object):
         self.assertItemsEqual(names, ds_names)
 
         # test iterating over a specific subset
-        subset = ds_names[:3]
+        subset_index = 3 if self.number_datasets_used_in_testing > 3 \
+            else self.number_datasets_used_in_testing
+        subset = ds_names[:subset_index]
         names = [
             ds.name for ds in engine.iter_datasets(subset)]
         self.assertEqual(names, subset)
@@ -173,7 +176,7 @@ class CheckEngine(object):
     def test_delete_dataset(self):
         engine = self.engine_factory()
         # add a few empty datasets
-        for i in xrange(5):
+        for i in xrange(self.number_datasets_used_in_testing):
             name = "test_" + str(i)
             engine.add_dataset(self.create_dataset(name=name))
 
@@ -220,8 +223,8 @@ class CheckEngine(object):
 
 class ParticlesEngineCheck(CheckEngine):
 
-    def setUp(self):
-        CheckEngine.setUp(self)
+    def setUp(self, number_datasets_used_in_testing=5):
+        CheckEngine.setUp(self, number_datasets_used_in_testing)
 
     def compare_dataset(self, dataset, reference):
         compare_particles_datasets(dataset, reference, self)
@@ -244,8 +247,8 @@ class ParticlesEngineCheck(CheckEngine):
 
 class MeshEngineCheck(CheckEngine):
 
-    def setUp(self):
-        CheckEngine.setUp(self)
+    def setUp(self, number_datasets_used_in_testing=5):
+        CheckEngine.setUp(self, number_datasets_used_in_testing)
 
     def compare_dataset(self, dataset, reference):
         compare_mesh_datasets(dataset, reference, self)
@@ -268,8 +271,8 @@ class MeshEngineCheck(CheckEngine):
 
 class LatticeEngineCheck(CheckEngine):
 
-    def setUp(self):
-        CheckEngine.setUp(self)
+    def setUp(self, number_datasets_used_in_testing=5):
+        CheckEngine.setUp(self, number_datasets_used_in_testing)
 
     def compare_dataset(self, dataset, reference):
         compare_lattice_datasets(dataset, reference, self)

--- a/simphony/testing/abc_check_engine.py
+++ b/simphony/testing/abc_check_engine.py
@@ -215,12 +215,11 @@ class CheckEngine(object):
         # we should be able to access using the new "bar" name
         ds_bar = engine.get_dataset("bar")
         self.assertEqual(ds_bar.name, "bar")
-        if self.number_datasets_used_in_testing < 2:
-            engine.remove_dataset("bar")
 
         # and we should be able to use the no-longer used
         # "foo" name when adding another dataset
-        ds = engine.add_dataset(self.create_dataset(name='foo'))
+        if self.number_datasets_used_in_testing > 1:
+            ds = engine.add_dataset(self.create_dataset(name='foo'))
 
 
 class ParticlesEngineCheck(CheckEngine):


### PR DESCRIPTION
This PR addresses #221.  Some engines support only certain number of datasets (e.g. single-dataset engines).  This PR allows the number of datasets used during testing to be set.   For example, tests for an engine that only supported a single-lattice would look like the following.:

```
class MySingleLatticeEngineCheck(LatticeEngineCheck):
    def setUp(self):
        LatticeEngineCheck.setUp(self, number_datasets_used_in_testing=1)

```