### PR TITLE
Make travis fail if there are any sphinx/doc warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 script:
   - flake8 .
   - coverage run -m unittest discover -p test*
-  - python setup.py build_sphinx
+  - sphinx-build -W doc/source doc/build/sphinx
 after_success:
   - pip install codecov
   - codecov

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,6 +12,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import sphinx.environment
+from docutils.utils import get_source_line
+
+def _warn_node(self, msg, node):
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node
 
 def mock_modules():
     import sys


### PR DESCRIPTION
This PR does the following
 *  Ignores the warnings from sphinx related to the non-local badge images 
 *  Turn sphinx warnings into errors when building documentation on Travis-CI (so that travis fails when there are warnings related to the documenation)