### PR TITLE
Update  cuba_generate.py generated dtype is uuid.UUID

### DIFF
--- a/simphony/scripts/cuba_generate.py
+++ b/simphony/scripts/cuba_generate.py
@@ -147,6 +147,7 @@ def keywords(input, output):
         'from collections import namedtuple\n',
         '\n',
         'import numpy\n',
+        'import uuid\n',
         '\n',
         '\n',
         'ATTRIBUTES = [\n'
@@ -156,7 +157,7 @@ def keywords(input, output):
         '\n',
         'KEYWORDS = {\n']
     data_types = {
-        'uuid': "'uuid'",
+        'uuid': 'uuid.UUID',
         'string': 'numpy.str',
         'double': 'numpy.float64',
         'integer': 'numpy.int32'}


### PR DESCRIPTION
 This PR updates the `cuba_generate.py`script so that the dtype is uuid.UUID (instead of 'uuid').

