### PR TITLE
Fix flake error in master

### DIFF
--- a/simphony/tools/tests/test_lattice_tools.py
+++ b/simphony/tools/tests/test_lattice_tools.py
@@ -361,9 +361,9 @@ class TestLatticeTools(unittest.TestCase):
             p1, p2, p3 = rotate_permute_flip(aligned_vectors)
 
             # when
-            exclusives = (set(BravaisLattice)
-                          - set(specific_map2_general[bravais_lattice])
-                          - set([bravais_lattice, BravaisLattice.TRICLINIC]))
+            exclusives = (set(BravaisLattice) -
+                          set(specific_map2_general[bravais_lattice]) -
+                          set([bravais_lattice, BravaisLattice.TRICLINIC]))
 
             # then
             # bravais_lattice cannot be compatible with lattice


### PR DESCRIPTION
CI for master is failing:
```
$ flake8 .

./simphony/tools/tests/test_lattice_tools.py:365:27: W503 line break before binary operator

./simphony/tools/tests/test_lattice_tools.py:366:27: W503 line break before binary operator
```