### PR TITLE
Add CUDS support to SimPhoNy

### DIFF
--- a/doc/source/api/cuds.rst
+++ b/doc/source/api/cuds.rst
@@ -1,7 +1,6 @@
 CUDS
 ====
 
-
 Abstract CUDS interfaces
 ------------------------
 
@@ -32,6 +31,27 @@ Abstract CUDS interfaces
    :undoc-members:
 
 .. automodule:: simphony.cuds.abc_modeling_engine
+   :members:
+   :undoc-members:
+
+CUDS Computational Model
+------------------------
+.. rubric:: Container and Simulation
+
+.. currentmodule:: simphony.cuds
+
+.. autosummary::
+
+   ~model.CUDS
+   ~simulation.Simulation
+
+.. rubric:: Description
+
+.. automodule:: simphony.cuds.model
+   :members:
+   :undoc-members:
+
+.. automodule:: simphony.cuds.simulation
    :members:
    :undoc-members:
 

--- a/doc/source/api/extension.rst
+++ b/doc/source/api/extension.rst
@@ -1,0 +1,38 @@
+Engine Extensions
+=================
+
+Base class and tools for loading engine extension metadata into SimPhoNy.
+
+For information on engine entry points, see :doc:`../extending_simphony`
+
+.. rubric:: Classes
+
+.. currentmodule:: simphony.engine
+
+.. autosummary::
+
+   ~extension.ABCEngineExtension
+   ~extension.EngineInterface
+   ~extension.EngineMetadata
+   ~extension.EngineFeatureMetadata
+   ~extension.EngineManagerException
+   ~extension.EngineManager
+
+.. rubric:: Functions
+
+.. autosummary::
+
+   ~get_supported_engine_names
+   ~get_supported_engines
+
+.. rubric:: Implementation
+
+.. automodule:: simphony.engine.extension
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: simphony.engine
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/extending_simphony.rst
+++ b/doc/source/extending_simphony.rst
@@ -109,7 +109,7 @@ create a wrapper instance and return it.
 
 The other method is ``get_supported_engines``. This method must create and return a list of
 the engine's features. Features are simply a pair of physics equation and a list of methods
-that the corresponing egnine provides in order to solve the physics equation. Features are
+that the corresponing engine provides in order to solve the physics equation. Features are
 created by calling the ``create_engine_metadata_feature``. After creating features one must
 pass them to the ``create_engine_metadata`` method in order to create metadata objects. Each
 engine metadata object is a pair of engine name and a list of features provided by that engine.

--- a/doc/source/extending_simphony.rst
+++ b/doc/source/extending_simphony.rst
@@ -110,8 +110,8 @@ create a wrapper instance and return it.
 The other method is ``get_supported_engines``. This method must create and return a list of
 the engine's features. Features are simply a pair of physics equation and a list of methods
 that the corresponing egnine provides in order to solve the physics equation. Features are
-create by calling the ``create_engine_metadata_feature``. After creating features one must
-pass the to the ``create_engine_metadata`` method in order to create metadata objects. Each
+created by calling the ``create_engine_metadata_feature``. After creating features one must
+pass them to the ``create_engine_metadata`` method in order to create metadata objects. Each
 engine metadata object is a pair of engine name and a list of features provided by that engine.
 
 Having this class implemented in the wrapper plugin, one can query for the available engines::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,6 +28,7 @@ API Reference
    api/core
    api/cuds
    api/io
+   api/extension
 
 
 Indices and tables

--- a/simphony/__init__.py
+++ b/simphony/__init__.py
@@ -12,4 +12,8 @@ For more information see: http://www.simphony-project.eu/.
 
 :copyright: (c) 2014, 2015, 2016 SimPhoNy Consortium
 :license: BSD, see LICENSE for more details.
+
+This module exports the public interface of the SimPhoNy project.
 """
+from .core import CUBA
+from .cuds import CUDS, Simulation

--- a/simphony/__init__.py
+++ b/simphony/__init__.py
@@ -17,3 +17,6 @@ This module exports the public interface of the SimPhoNy project.
 """
 from .core import CUBA
 from .cuds import CUDS, Simulation
+
+
+__all__ = ['CUBA', 'CUDS', 'Simulation']

--- a/simphony/core/__init__.py
+++ b/simphony/core/__init__.py
@@ -1,3 +1,6 @@
 """The core CUDS entities based on SimPhoNy metadata."""
 from .cuba import CUBA
 from .data_container import DataContainer
+
+
+__all__ = ['CUBA', 'DataContainer']

--- a/simphony/core/__init__.py
+++ b/simphony/core/__init__.py
@@ -1,0 +1,3 @@
+"""The core CUDS entities based on SimPhoNy metadata."""
+from .cuba import CUBA
+from .data_container import DataContainer

--- a/simphony/cuds/__init__.py
+++ b/simphony/cuds/__init__.py
@@ -4,9 +4,11 @@ from .abc_particles import ABCParticles
 from .mesh import Mesh, Point, Element, Edge, Face, Cell
 from .lattice import Lattice, LatticeNode
 from .particles import Particles, Particle, Bond
+from .model import CUDS
+from .simulation import Simulation
 
 __all__ = [
     'ABCLattice', 'ABCMesh', 'ABCParticles',
     'Mesh', 'Point', 'Element', 'Edge', 'Face', 'Cell',
     'Lattice', 'LatticeNode',
-    'Particles', 'Particle', 'Bond']
+    'Particles', 'Particle', 'Bond', 'CUDS', 'Simulation']

--- a/simphony/cuds/abc_modeling_engine.py
+++ b/simphony/cuds/abc_modeling_engine.py
@@ -1,3 +1,6 @@
+"""This module is part of simphony-common package. It contains
+wrappers base class.
+"""
 from abc import ABCMeta, abstractmethod
 
 
@@ -21,6 +24,31 @@ class ABCModelingEngine(object):  # pragma: no cover
 
     """
     __metaclass__ = ABCMeta
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the engine.
+
+        Parameters
+        ----------
+        cuds:
+            The CUDS computational model object
+
+        Returns
+        -------
+
+        """
+        self._cuds = kwargs.get('cuds')
+        self._load_cuds()
+
+    # This class is supposed to be overridden, however it is not labeled
+    # abstract, in order to be backward-compatible.
+    def _load_cuds(self):
+        """Load information from CUDS into the engine."""
+        pass
+
+    def get_cuds(self):
+        """Get current CUDS instance."""
+        return self._cuds
 
     @abstractmethod
     def run(self):

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -105,10 +105,3 @@ class CUDS(object):
         for component in self._store.iteritems():
             if isinstance(component, component_type):
                 yield component.name
-
-    def change_datastore(self, store):
-        """Replace the current dataset store with the given one.
-
-        This method is intented to be used from wrappers. A wrapper will
-        switch the store to its own proxy store after getting the cuds."""
-        self._dataset_store = store

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -33,11 +33,11 @@ class CUDS(object):
     @property
     def data(self):
         """Data container for CUDS items."""
-        return self._data
+        return DataContainer(self._data)
 
     @data.setter
-    def data_setter(self):
-        raise Exception('Replacing data container is not supported.')
+    def data_setter(self, value):
+        self._data = DataContainer(value)
 
     def add(self, component):
         """Adds a component to the CUDS computational model.

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -1,6 +1,7 @@
 """CUDS computational model implementation.
 
-This module contains the classes used to represent a computational model, based on SimPhoNy metadata.
+This module contains the classes used to represent a computational model,
+based on SimPhoNy metadata.
 """
 from ..core import DataContainer
 from .store import MemoryStateDataStore

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -51,10 +51,7 @@ class CUDS(object):
     @staticmethod
     def _is_dataset(obj):
         """Check if the object is a dataset."""
-        if isinstance(obj, (ABCParticles, ABCLattice, ABCMesh)):
-            return True
-        else:
-            return False
+        return isinstance(obj, (ABCParticles, ABCLattice, ABCMesh))
 
     @property
     def data(self):

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -66,7 +66,7 @@ class CUDS(object):
         self._data = DataContainer(value)
 
     def add(self, component):
-        """Adds a component to the CUDS computational model.
+        """Add a component to the CUDS computational model.
 
         Parameters
         ----------
@@ -95,8 +95,13 @@ class CUDS(object):
 
         Parameters
         ----------
-        component_id: str
+        component_id: uuid.UUID
             key of a CUDS component.
+
+        Returns
+        -------
+        component: CUDSComponent
+            a cuds component
         """
         if not isinstance(component_id, (str, uuid.UUID)):
             raise TypeError('ID should be of string or UUID type')
@@ -110,7 +115,7 @@ class CUDS(object):
 
         Parameters
         ----------
-        component_id: CUDSComponent uuid
+        component_id: uuid.UUID
             a component of CUDS, reflecting SimPhoNy metadata
         """
         if not isinstance(component_id, (str, uuid.UUID)):
@@ -135,9 +140,9 @@ class CUDS(object):
         component_type: CUDSComponent class
             a component of CUDS, reflecting SimPhoNy metadata
 
-        Returns
-        -------
-        An iterator over results
+        Yields
+        ------
+        An iterator over the components
         """
         for component in self._store.itervalues():
             if isinstance(component, component_type):
@@ -153,7 +158,8 @@ class CUDS(object):
 
         Returns
         -------
-        list: list of names of the items of the given type
+        names: list
+            names of the items of the given type
         """
         if any([issubclass(component_type, ABCParticles),
                issubclass(component_type, ABCLattice),

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -32,7 +32,7 @@ class CUDS(object):
         # The generic data container
         self._data = DataContainer()
 
-        # A map to find the object for a given id amoung datasets or
+        # A map to find the object for a given id among datasets or
         # simple components. Unfortunately, at the moment dataset
         # containers do not have `uid' and therefore this workaround
         # is necessary. This is a dict of key of any kind and a lambda
@@ -96,7 +96,7 @@ class CUDS(object):
         Parameters
         ----------
         component_id: uuid.UUID
-            key of a CUDS component.
+            key of a CUDS component
 
         Returns
         -------
@@ -142,7 +142,7 @@ class CUDS(object):
 
         Yields
         ------
-        An iterator over the components
+        iterator over the components of the given type
         """
         for component in self._store.itervalues():
             if isinstance(component, component_type):

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -1,0 +1,107 @@
+"""CUDS computational model implementation.
+
+This module contains the classes used to represent a computational model, based on SimPhoNy metadata.
+"""
+from ..core import DataContainer
+from .store import MemoryStateDataStore
+
+
+# IDEA: add consistency check handlers/instances to the CUDS class (dynamic).
+class CUDS(object):
+    """CUDS computational model."""
+    def __init__(self):
+
+        # Add datasets to memory datastore by default
+        self._dataset_store = MemoryStateDataStore()
+
+        # Memory storage to keep CUDS components
+        self._store = {}
+
+        # Data container
+        self._data = DataContainer()
+
+    @staticmethod
+    def _is_cuds_component(obj):
+        """Check whether the object is a CUDS component."""
+        # When I see a bird that walks like a duck and swims like a duck
+        # and quacks like a duck, I call that bird a duck
+        # TODO: replace with metadata type checks
+        return all([hasattr(obj, 'name'),
+                    hasattr(obj, 'data')])
+
+    @property
+    def data(self):
+        """Data container for CUDS items."""
+        return self._data
+
+    @data.setter
+    def data_setter(self):
+        raise Exception('Replacing data container is not supported.')
+
+    def add(self, component):
+        """Adds a component to the CUDS computational model.
+
+        Parameters
+        ----------
+        component: CUDSComponent
+            a component of CUDS, reflecting SimPhoNy metadata
+        """
+        # Check if the object is valid
+        if not self._is_cuds_component(component):
+            raise ValueError('Not a CUDS component.')
+
+        # Store the component
+        # TODO: use uuid of the component - does not exist yet
+        self._store[id(component)] = component
+
+    def get(self, component_id):
+        """Gets a component from the CUDS computational model.
+
+        Parameters
+        ----------
+        component_id: CUDSComponent's UUID
+            uuid of a CUDS component.
+        """
+        return self._store.get(component_id)
+
+    def remove(self, component_id):
+        """Removes a component from the CUDS computational model.
+
+        Parameters
+        ----------
+        component_id: CUDSComponent uuid
+            a component of CUDS, reflecting SimPhoNy metadata
+        """
+        self._store.remove(component_id)
+
+    # This should be query method
+    def iter(self, component_type):
+        """Returns an iterator for the components of the given type.
+
+        Parameters
+        ----------
+        component_type: CUDSComponent class
+            a component of CUDS, reflecting SimPhoNy metadata
+        """
+        for component in self._store.itervalues():
+            if isinstance(component, component_type):
+                yield component
+
+    def get_names(self, component_type):
+        """Get names of the components of the given type.
+
+        Parameters
+        ----------
+        component_type: CUDSComponent class
+            a component of CUDS, reflecting SimPhoNy metadata
+        """
+        for component in self._store.iteritems():
+            if isinstance(component, component_type):
+                yield component.name
+
+    def change_datastore(self, store):
+        """Replace the current dataset store with the given one.
+
+        This method is intented to be used from wrappers. A wrapper will
+        switch the store to its own proxy store after getting the cuds."""
+        self._dataset_store = store

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -9,7 +9,13 @@ from .store import MemoryStateDataStore
 
 # IDEA: add consistency check handlers/instances to the CUDS class (dynamic).
 class CUDS(object):
-    """CUDS computational model."""
+    """Common Universal Data Structure, i.e. CUDS computational model.
+
+    This is the main data structure to hold all the information regarding
+    a computational model. Having the data provided by this class, one should
+    be able to start a new computational model based on that with no extra
+    information.
+    """
     def __init__(self):
 
         # Add datasets to memory datastore by default

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -9,10 +9,10 @@ class Simulation(object):
     Parameters
     ----------
     cuds: CUDS
-        A cuds object which contains model information.
+        Model information.
     engine_name: str
-        Name of the underlying engine to launch the simulation with.
-    engine_interface: EngineInterface
+        Name of the underlying engine.
+    engine_interface: engine.EngineInterface
         The interface to the engine, internal or fileio.
     """
     def __init__(self, cuds, engine_name, engine_interface=None):
@@ -26,3 +26,13 @@ class Simulation(object):
     def run(self, *args, **kwargs):
         """Run the simulation."""
         self._wrapper.run(*args, **kwargs)
+
+    def get_cuds(self):
+        """Return the latest CUDS from the engine.
+
+        Returns
+        -------
+        cuds: CUDS
+            the most recent CUDS.
+        """
+        return self._wrapper.get_cuds()

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -18,7 +18,8 @@ class WrapperFactory(object):
         """
         wrapper = get_wrapper(wrapper_name)
         if not wrapper:
-            raise Exception('%s is unknown, accepted values are: %s' % (wrapper_name, ', '.join(get_wrappers())))
+            raise Exception('%s is unknown, accepted values are: %s' %
+                            (wrapper_name, ', '.join(get_wrappers())))
 
         return wrapper(cuds=cuds)
 

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -34,6 +34,8 @@ class Simulation(object):
         Name of the wrapper to launch the simulation with.
     """
     def __init__(self, cuds, wrapper_name):
+        if not isinstance(cuds, CUDS):
+            raise TypeError('Expected CUDS but got %s' % type(cuds))
         self._cuds = cuds
         self._wrapper = WrapperFactory.create(wrapper_name, cuds)
 

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -1,44 +1,27 @@
 """Contains simulation controllers."""
 from . import CUDS
-from ..engine import get_wrapper, get_wrappers
-
-
-class WrapperFactory(object):
-    """Creates wrappers."""
-    @staticmethod
-    def create(wrapper_name, cuds):
-        """Create a wrapper instance of the given name.
-
-        Parameters
-        ----------
-        cuds: CUDS
-            a cuds object containing simulation data
-        wrapper_name: str
-            A SimPhoNy wrapper name, should be of of registered engines.
-        """
-        wrapper = get_wrapper(wrapper_name)
-        if not wrapper:
-            raise Exception('%s is unknown, accepted values are: %s' %
-                            (wrapper_name, ', '.join(get_wrappers())))
-
-        return wrapper(cuds=cuds)
+from ..engine import create_wrapper
 
 
 class Simulation(object):
-    """Represents a simulation using CUDS.
+    """A CUDS computational model simulation.
 
     Parameters
     ----------
     cuds: CUDS
         A cuds object which contains model information.
-    wrapper_name: str
-        Name of the wrapper to launch the simulation with.
+    engine_name: str
+        Name of the underlying engine to launch the simulation with.
+    engine_interface: EngineInterface
+        The interface to the engine, internal or fileio.
     """
-    def __init__(self, cuds, wrapper_name):
+    def __init__(self, cuds, engine_name, engine_interface=None):
         if not isinstance(cuds, CUDS):
             raise TypeError('Expected CUDS but got %s' % type(cuds))
         self._cuds = cuds
-        self._wrapper = WrapperFactory.create(wrapper_name, cuds)
+        self._wrapper = create_wrapper(cuds,
+                                       engine_name,
+                                       engine_interface=engine_interface)
 
     def run(self, *args, **kwargs):
         """Run the simulation."""

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -1,6 +1,6 @@
 """Contains simulation controllers."""
 from . import CUDS
-from ..engine import get_wrapper
+from ..engine import get_wrapper, get_wrappers
 
 
 class WrapperFactory(object):
@@ -18,7 +18,7 @@ class WrapperFactory(object):
         """
         wrapper = get_wrapper(wrapper_name)
         if not wrapper:
-            raise Exception('Unknown wrapper: %s' % wrapper_name)
+            raise Exception('%s is unknown, accepted values are: %s' % (wrapper_name, ', '.join(get_wrappers())))
 
         return wrapper(cuds=cuds)
 

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -1,0 +1,42 @@
+"""Contains simulation controllers."""
+from . import CUDS
+from ..engine import get_wrapper
+
+
+class WrapperFactory(object):
+    """Creates wrappers."""
+    @staticmethod
+    def create(wrapper_name, cuds):
+        """Create a wrapper instance of the given name.
+
+        Parameters
+        ----------
+        cuds: CUDS
+            a cuds object containing simulation data
+        wrapper_name: str
+            A SimPhoNy wrapper name, should be of of registered engines.
+        """
+        wrapper = get_wrapper(wrapper_name)
+        if not wrapper:
+            raise Exception('Unknown wrapper: %s' % wrapper_name)
+
+        return wrapper(cuds=cuds)
+
+
+class Simulation(object):
+    """Represents a simulation using CUDS.
+
+    Parameters
+    ----------
+    cuds: CUDS
+        A cuds object which contains model information.
+    wrapper_name: str
+        Name of the wrapper to launch the simulation with.
+    """
+    def __init__(self, cuds, wrapper_name):
+        self._cuds = cuds
+        self._wrapper = WrapperFactory.create(wrapper_name, cuds)
+
+    def run(self, *args, **kwargs):
+        """Run the simulation."""
+        self._wrapper.run(*args, **kwargs)

--- a/simphony/cuds/store.py
+++ b/simphony/cuds/store.py
@@ -1,0 +1,90 @@
+"""Base storage mechanism for accessing CUDS entities, mainly datasets.
+
+This module contains the base class for implementing different access strategies
+for CUDS,notably MemoryStore and ProxyStore.
+"""
+import abc
+
+
+class ABCStateDataStore(object):
+    """Abstract base class for all stores.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def add(self, dataset, *args, **kwargs):
+        """Add the dataset to the store."""
+
+    @abc.abstractmethod
+    def get(self, name):
+        """Return the dataset with the given name."""
+
+    @abc.abstractmethod
+    def remove(self, name):
+        """Remove the dataset with the given name."""
+
+    @abc.abstractmethod
+    def get_names(self):
+        """Return names of the existing datasets."""
+
+    @abc.abstractmethod
+    def iter_datasets(self, names=None):
+        """Iterate over all or a subset of datasets."""
+
+
+class MemoryStateDataStore(ABCStateDataStore):
+    """A dataset store that keeps everything in memory."""
+    def __init__(self, *args, **kwargs):
+        self._datasets = {}
+
+    def add(self, dataset, *args, **kwargs):
+        """Add the dataset to the store."""
+        self._datasets[dataset.name] = dataset
+
+    def get(self, name):
+        """Return the dataset with the given name."""
+        return self._datasets.get(name)
+
+    def remove(self, name):
+        """Remove the dataset with the given name."""
+        del self._datasets[name]
+
+    def get_names(self):
+        """Return names of the existing datasets."""
+        return self._datasets.keys()
+
+    def iter_datasets(self, names=None):
+        """Iterate over all or a subset of datasets."""
+        if not names:
+            names = self._datasets.keys()
+
+        for key in self._datasets:
+            if key in names:
+                yield self._datasets.get(key)
+
+
+class ProxyStateDataStore(ABCStateDataStore):
+    """A dataset store that reads its values from a wrapper."""
+    def __init__(self, wrapper, *args, **kwargs):
+        self._wrapper = wrapper
+
+    def add(self, dataset, *args, **kwargs):
+        """Add the dataset to the store."""
+        self._wrapper.add_dataset(dataset)
+
+    def get(self, name):
+        """Return the dataset with the given name."""
+	return self._wrapper.get_dataset(name)
+
+    def remove(self, name):
+        """Remove the dataset with the given name."""
+	self._wrapper.remove_dataset(name)
+
+    def get_names(self):
+        """Return names of the existing datasets."""
+	return self._wrapper.get_dataset_names()
+
+    def iter_datasets(self, names=None):
+        """Iterate over all or a subset of datasets."""
+	return self._wrapper.iter_datasets(names=names)
+

--- a/simphony/cuds/store.py
+++ b/simphony/cuds/store.py
@@ -40,7 +40,7 @@ class MemoryStateDataStore(ABCStateDataStore):
     def add(self, dataset, *args, **kwargs):
         """Add the dataset to the store."""
         if dataset.name in self._datasets:
-            raise Exception('Dateset %s already exists.' % dataset.name)
+            raise Exception('Dataset %s already exists.' % dataset.name)
         self._datasets[dataset.name] = dataset
 
     def get(self, name):

--- a/simphony/cuds/store.py
+++ b/simphony/cuds/store.py
@@ -1,7 +1,7 @@
 """Base storage mechanism for accessing CUDS entities, mainly datasets.
 
-This module contains the base class for implementing different access strategies
-for CUDS,notably MemoryStore and ProxyStore.
+This module contains the base class for implementing different access
+strategies for CUDS,notably MemoryStore and ProxyStore.
 """
 import abc
 
@@ -74,17 +74,16 @@ class ProxyStateDataStore(ABCStateDataStore):
 
     def get(self, name):
         """Return the dataset with the given name."""
-	return self._wrapper.get_dataset(name)
+        return self._wrapper.get_dataset(name)
 
     def remove(self, name):
         """Remove the dataset with the given name."""
-	self._wrapper.remove_dataset(name)
+        self._wrapper.remove_dataset(name)
 
     def get_names(self):
         """Return names of the existing datasets."""
-	return self._wrapper.get_dataset_names()
+        return self._wrapper.get_dataset_names()
 
     def iter_datasets(self, names=None):
         """Iterate over all or a subset of datasets."""
-	return self._wrapper.iter_datasets(names=names)
-
+        return self._wrapper.iter_datasets(names=names)

--- a/simphony/cuds/store.py
+++ b/simphony/cuds/store.py
@@ -39,6 +39,8 @@ class MemoryStateDataStore(ABCStateDataStore):
 
     def add(self, dataset, *args, **kwargs):
         """Add the dataset to the store."""
+        if dataset.name in self._datasets:
+            raise Exception('Dateset %s already exists.' % dataset.name)
         self._datasets[dataset.name] = dataset
 
     def get(self, name):
@@ -60,7 +62,7 @@ class MemoryStateDataStore(ABCStateDataStore):
 
         for key in self._datasets:
             if key in names:
-                yield self._datasets.get(key)
+                yield self._datasets[key]
 
 
 class ProxyStateDataStore(ABCStateDataStore):

--- a/simphony/cuds/tests/test_cuds.py
+++ b/simphony/cuds/tests/test_cuds.py
@@ -1,0 +1,105 @@
+"""Tests for CUDS data structure."""
+import unittest
+import uuid
+
+from simphony import CUDS
+from simphony.cuds.particles import Particle, Particles
+
+
+class CUDSTestCase(unittest.TestCase):
+    """CUDS class tests."""
+    def setUp(self):
+        self.cuds = CUDS()
+
+        # TODO: use generated components
+        class DummyComponent(object):
+            def __init__(self):
+                self.uuid = uuid.uuid4()
+                self.name = 'dummyname'
+                self.data = {}
+        self.dummpy_component1 = DummyComponent()
+        self.dummpy_component2 = DummyComponent()
+
+    def test_empty_cuds(self):
+        self.assertEqual(len(self.cuds.data), 0)
+        self.assertEqual(self.cuds.get('nonexistentkey'), None)
+        self.assertEqual(self.cuds.data, {})
+        self.assertRaises(KeyError, self.cuds.remove, 'nonexistentkey')
+
+    def test_data(self):
+        data = self.cuds.data
+        self.assertEqual(self.cuds.data, data)
+        self.assertIsNot(self.cuds.data, data)
+
+    def test_get(self):
+        self.assertRaises(TypeError,
+                          self.cuds.get,
+                          42)
+
+    def test_add_get_component(self):
+        self.assertRaises(ValueError, self.cuds.add, object())
+        self.cuds.add(self.dummpy_component1)
+        self.assertEqual(self.cuds.get(self.dummpy_component1.uuid),
+                         self.dummpy_component1)
+
+    def test_add_dataset(self):
+        p1 = Particle()
+        p2 = Particle()
+        ps = Particles('my particles')
+        ps.add_particles([p1, p2])
+
+        self.cuds.add(ps)
+        self.assertEqual(self.cuds.get(ps.name), ps)
+
+    def test_remove_component(self):
+        self.cuds.add(self.dummpy_component1)
+        self.cuds.remove(self.dummpy_component1.uuid)
+        self.assertIsNone(self.cuds.get(self.dummpy_component1.uuid))
+
+    def test_remove_dataset(self):
+        p1 = Particle()
+        p2 = Particle()
+        ps = Particles('my particles')
+        ps.add_particles([p1, p2])
+        self.cuds.add(ps)
+        self.cuds.remove(ps.name)
+        self.assertIsNone(self.cuds.get(ps.name))
+
+    def test_get_names(self):
+        p1 = Particle()
+        p2 = Particle()
+        p3 = Particle()
+        p4 = Particle()
+        ps1 = Particles('M1')
+        ps2 = Particles('M2')
+        ps1.add_particles([p1, p2])
+        ps2.add_particles([p3, p4])
+        self.cuds.add(ps1)
+        self.cuds.add(ps2)
+        self.assertEqual(self.cuds.get_names(Particles), ['M1', 'M2'])
+
+        self.cuds.add(self.dummpy_component1)
+        self.cuds.add(self.dummpy_component2)
+        self.assertEqual(self.cuds.get_names(type(self.dummpy_component1)),
+                         [self.dummpy_component1.name,
+                          self.dummpy_component2.name])
+
+    def test_iter(self):
+        p1 = Particle()
+        p2 = Particle()
+        p3 = Particle()
+        p4 = Particle()
+        ps1 = Particles('M1')
+        ps2 = Particles('M2')
+        ps1.add_particles([p1, p2])
+        ps2.add_particles([p3, p4])
+        self.cuds.add(ps1)
+        self.cuds.add(ps2)
+        for item in self.cuds.iter(Particles):
+            self.assertIn(item, [ps1, ps2])
+
+        self.cuds.add(self.dummpy_component1)
+        self.cuds.add(self.dummpy_component2)
+        for item in self.cuds.iter(type(self.dummpy_component1)):
+            self.assertIn(item, [self.dummpy_component1,
+                                 self.dummpy_component2])

--- a/simphony/cuds/tests/test_simulation.py
+++ b/simphony/cuds/tests/test_simulation.py
@@ -1,0 +1,64 @@
+"""Tests for Simulation classes."""
+import unittest
+
+from simphony import CUDS
+from simphony import Simulation
+from simphony.engine.extension import EngineManager
+from simphony.engine.tests.test_engine_metadata import \
+    get_example_engine_extension
+import simphony.engine as engine_api
+
+
+class SimulationTestCase(unittest.TestCase):
+    """Simulation tests."""
+    def setUp(self):
+        self.manager = EngineManager()
+        module_with_dummy_extensions = \
+            __import__('simphony.engine.tests.test_engine_metadata')
+        self.manager.load_metadata(module_with_dummy_extensions)
+        cls = get_example_engine_extension()
+        self.manager.add_extension(cls())
+        # Patch api for test
+        engine_api._ENGINE_MANAGER = self.manager
+
+    def test_empty_simulation(self):
+        cuds = CUDS()
+        engine_names = self.manager.get_supported_engine_names()
+        # There should be at least one dummy extension there
+        self.assertGreater(len(engine_names), 0)
+        engine_a_name = engine_names[0]
+        engine_a = None
+        for engine_ext in self.manager.get_supported_engines():
+            for engine in engine_ext.get_supported_engines():
+                if engine.name == engine_a_name:
+                    engine_a = engine
+
+        self.assertIsNotNone(engine_a)
+        self.assertGreater(len(engine_a.interfaces), 0)
+
+        sim = Simulation(cuds,
+                         engine_a_name,
+                         engine_a.interfaces[0])
+
+        self.assertIsNotNone(sim)
+
+    def test_run(self):
+        cuds = CUDS()
+        engine_names = self.manager.get_supported_engine_names()
+        # There should be at least one dummy extension there
+        self.assertGreater(len(engine_names), 0)
+        engine_a_name = engine_names[0]
+        engine_a = None
+        for engine_ext in self.manager.get_supported_engines():
+            for engine in engine_ext.get_supported_engines():
+                if engine.name == engine_a_name:
+                    engine_a = engine
+
+        self.assertIsNotNone(engine_a)
+        self.assertGreater(len(engine_a.interfaces), 0)
+
+        sim = Simulation(cuds,
+                         engine_a_name,
+                         engine_a.interfaces[0])
+        sim.run()
+        self.assertEqual(sim.get_cuds(), cuds)

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -23,7 +23,7 @@ def get_wrapper(wrapper_name):
 
 
 def get_wrappers():
-    """Return a list of know wrappers."""
+    """Return a list of known wrappers."""
     return _WRAPPER_REGISTRY.keys()
 
 

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -7,6 +7,25 @@ registered at the 'simphony.engine' entry point.
 
 """
 
+# A temporary solution to keep a list of wrappers known to SimPhoNy
+_WRAPPER_REGISTRY = {}
+
+
+def get_wrapper(wrapper_name):
+    """Return corresponding wrapper class.
+
+    Parameters
+    ----------
+    wrapper_name: str
+        name that wrapper is registered with.
+    """
+    return _WRAPPER_REGISTRY.get(wrapper_name)
+
+
+def get_wrappers():
+    """Return a list of know wrappers."""
+    return _WRAPPER_REGISTRY.keys()
+
 
 def load_engine_extentions():
     """ Discover and load engine extension modules.
@@ -16,7 +35,15 @@ def load_engine_extentions():
     mgr = extension.ExtensionManager(
         namespace='simphony.engine',
         invoke_on_load=False)
-    return {extension.name: extension.plugin for extension in mgr.extensions}
+    extensions = {}
+    for extension in mgr.extensions:
+        extensions[extension.name] = extension.plugin
+        # Invoke 'get_wrappers' method and register wrappers.
+        if hasattr(extension.plugin, 'get_wrappers'):
+            wrappers = extension.plugin.get_wrappers()
+            if wrappers:
+                _WRAPPER_REGISTRY.update(wrappers)
+    return extensions
 
 
 # Populate the module namespace

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -25,7 +25,7 @@ def get_supported_engine_names():
     Returns
     -------
     names: list
-        a list of engine names.
+        a list of engine names
     """
     return _ENGINE_MANAGER.get_supported_engine_names()
 
@@ -47,11 +47,11 @@ def create_wrapper(cuds, engine_name, engine_interface=None):
     Parameters
     ----------
     cuds: CUDS
-        A cuds object which contains model information.
+        a cuds object which contains model information
     engine_name: str
-        Name of the underlying engine to launch the simulation with.
+        name of the underlying engine to launch the simulation with
     engine_interface: engine.EngineInterface
-        The interface to the engine, internal or fileio.
+        the interface to the engine, internal or fileio
 
     Returns
     -------

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -36,11 +36,11 @@ def load_engine_extentions():
         namespace='simphony.engine',
         invoke_on_load=False)
     extensions = {}
-    for extension in mgr.extensions:
-        extensions[extension.name] = extension.plugin
+    for ext in mgr.extensions:
+        extensions[ext.name] = ext.plugin
         # Invoke 'get_wrappers' method and register wrappers.
-        if hasattr(extension.plugin, 'get_wrappers'):
-            wrappers = extension.plugin.get_wrappers()
+        if hasattr(ext.plugin, 'get_wrappers'):
+            wrappers = ext.plugin.get_wrappers()
             if wrappers:
                 _WRAPPER_REGISTRY.update(wrappers)
     return extensions

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -6,7 +6,6 @@ registered at the 'simphony.engine' entry point.
 
 
 """
-
 # A temporary solution to keep a list of wrappers known to SimPhoNy
 _WRAPPER_REGISTRY = {}
 
@@ -27,6 +26,26 @@ def get_wrappers():
     return _WRAPPER_REGISTRY.keys()
 
 
+def _update_wrappers(wrappers):
+    """Update the wrapper registry.
+
+    Parameters
+    ----------
+    wrappers: dict
+        key/ABCModelingEngine class pairs
+    """
+    if not wrappers:
+        return
+
+    if not isinstance(wrappers, dict):
+        raise TypeError('Must be a dict of key/ABCModelingEngine pairs.')
+
+    for key in wrappers.keys():
+        if key in _WRAPPER_REGISTRY:
+            raise ValueError('A wrapper already exists for the key %s' % key)
+    _WRAPPER_REGISTRY.update(wrappers)
+
+
 def load_engine_extentions():
     """ Discover and load engine extension modules.
 
@@ -39,10 +58,9 @@ def load_engine_extentions():
     for ext in mgr.extensions:
         extensions[ext.name] = ext.plugin
         # Invoke 'get_wrappers' method and register wrappers.
-        if hasattr(ext.plugin, 'get_wrappers'):
-            wrappers = ext.plugin.get_wrappers()
-            if wrappers:
-                _WRAPPER_REGISTRY.update(wrappers)
+        if hasattr(ext.plugin, 'get_wrappers') and \
+                callable(ext.plugin.get_wrappers):
+            _update_wrappers(ext.plugin.get_wrappers())
     return extensions
 
 

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -50,12 +50,12 @@ def create_wrapper(cuds, engine_name, engine_interface=None):
         A cuds object which contains model information.
     engine_name: str
         Name of the underlying engine to launch the simulation with.
-    engine_interface: EngineInterface
+    engine_interface: engine.EngineInterface
         The interface to the engine, internal or fileio.
 
     Returns
     -------
-    wrapper: ABCEngineExtension
+    wrapper: engine.ABCEngineExtension
         an engine wrapper instance
     """
     return _ENGINE_MANAGER.create_wrapper(cuds, engine_name, engine_interface)

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -18,6 +18,16 @@ __all__ = ['ABCEngineExtension', 'EngineInterface',
 _ENGINE_MANAGER = EngineManager()
 
 
+def get_supported_engine_names():
+    """Show a list of supported engines.
+
+    Returns
+    -------
+    list: a list of engine names
+    """
+    return _ENGINE_MANAGER.get_supported_engine_names()
+
+
 def get_supported_engines():
     """Show a list of supported engines."""
     return _ENGINE_MANAGER.get_supported_engines()

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -9,6 +9,10 @@ from .extension import EngineInterface
 from .extension import EngineManager
 
 
+__all__ = ['ABCEngineExtension', 'EngineInterface',
+           'get_supported_engines', 'create_wrapper']
+
+
 # TODO: Use an application server and put this in app context.
 # Wrapper manager class.
 _ENGINE_MANAGER = EngineManager()

--- a/simphony/engine/__init__.py
+++ b/simphony/engine/__init__.py
@@ -10,7 +10,8 @@ from .extension import EngineManager
 
 
 __all__ = ['ABCEngineExtension', 'EngineInterface',
-           'get_supported_engines', 'create_wrapper']
+           'get_supported_engines', 'create_wrapper',
+           'get_supported_engine_names']
 
 
 # TODO: Use an application server and put this in app context.
@@ -19,17 +20,24 @@ _ENGINE_MANAGER = EngineManager()
 
 
 def get_supported_engine_names():
-    """Show a list of supported engines.
+    """Show a list of supported engine names.
 
     Returns
     -------
-    list: a list of engine names
+    names: list
+        a list of engine names.
     """
     return _ENGINE_MANAGER.get_supported_engine_names()
 
 
 def get_supported_engines():
-    """Show a list of supported engines."""
+    """Show a list of supported engines.
+
+    Returns
+    -------
+    metadata: list
+        a list of engine metadata objects
+    """
     return _ENGINE_MANAGER.get_supported_engines()
 
 
@@ -44,6 +52,11 @@ def create_wrapper(cuds, engine_name, engine_interface=None):
         Name of the underlying engine to launch the simulation with.
     engine_interface: EngineInterface
         The interface to the engine, internal or fileio.
+
+    Returns
+    -------
+    wrapper: ABCEngineExtension
+        an engine wrapper instance
     """
     return _ENGINE_MANAGER.create_wrapper(cuds, engine_name, engine_interface)
 

--- a/simphony/engine/extension.py
+++ b/simphony/engine/extension.py
@@ -55,7 +55,7 @@ class EngineMetadata(object):
     features: list
       features of this engine as a list of EngineFeatureMetadata objects
     interfaces: list
-      supported engine interfaces as a list of EngineInterface enums
+      supported engine interfaces as a list of engine.EngineInterface enums
 
     """
     def __init__(self, name, features, interfaces):
@@ -87,7 +87,7 @@ class ABCEngineExtension(object):
           CUDS computational model data
         engine_name: str
           name of the engine, must be supported by this extension
-        engine_interface: EngineInterface
+        engine_interface: engine.EngineInterface
           the interface to interact with engine
 
         Returns
@@ -106,7 +106,7 @@ class ABCEngineExtension(object):
         features: list
           features of this engine as a list of EngineFeatureMetadata objects
         interfaces: list
-          supported engine interfaces as a list of EngineInterface enums
+          supported engine interfaces as a list of engine.EngineInterface enums
 
         Returns
         -------
@@ -166,7 +166,7 @@ class EngineManager(object):
 
         Parameters
         ----------
-        extension: ABCEngineExtension
+        extension: engine.ABCEngineExtension
           an extension that has knowledge about its own engines.
         """
         for engine in extension.get_supported_engines():
@@ -187,7 +187,7 @@ class EngineManager(object):
             A cuds object which contains model information.
         engine_name: str
             Name of the underlying engine to launch the simulation with.
-        engine_interface: EngineInterface
+        engine_interface: engine.EngineInterface
             The interface to the engine, internal or fileio.
         """
         if engine_name in self._engine_extensions:

--- a/simphony/engine/extension.py
+++ b/simphony/engine/extension.py
@@ -51,7 +51,7 @@ class EngineMetadata(object):
     Parameters
     ----------
     name: str
-      fixed name of a support engine to be used in user's data, i.e. key.
+      fixed name of a support engine to be used in user's data, i.e. key
     features: list
       features of this engine as a list of EngineFeatureMetadata objects
     interfaces: list
@@ -102,7 +102,7 @@ class ABCEngineExtension(object):
         Parameters
         ----------
         name: str
-          fixed name of a support engine to be used in user's data, i.e. key.
+          fixed name of a support engine to be used in user's data, i.e. key
         features: list
           features of this engine as a list of EngineFeatureMetadata objects
         interfaces: list
@@ -145,7 +145,7 @@ class EngineManager(object):
          interactions with corresponding engines.
 
         plugin: module
-          A python module provided by an extension
+          a python module provided by an extension
         """
         if not inspect.ismodule(plugin):
             raise EngineManagerException(
@@ -167,7 +167,7 @@ class EngineManager(object):
         Parameters
         ----------
         extension: engine.ABCEngineExtension
-          an extension that has knowledge about its own engines.
+          an extension that has knowledge about its own engines
         """
         for engine in extension.get_supported_engines():
             if engine.name in self._engine_extensions:
@@ -184,11 +184,11 @@ class EngineManager(object):
         Parameters
         ----------
         cuds: CUDS
-            A cuds object which contains model information.
+            a cuds object which contains model information
         engine_name: str
-            Name of the underlying engine to launch the simulation with.
+            name of the underlying engine to launch the simulation with
         engine_interface: engine.EngineInterface
-            The interface to the engine, internal or fileio.
+            the interface to the engine, internal or fileio
         """
         if engine_name in self._engine_extensions:
             extension = self._engine_extensions[engine_name]
@@ -205,7 +205,8 @@ class EngineManager(object):
 
         Returns
         -------
-        list: a list of EngineMetadata objects
+        metadata: list
+            a list of EngineMetadata objects
         """
         return list(self._engine_extensions.values())
 
@@ -214,6 +215,7 @@ class EngineManager(object):
 
         Returns
         -------
-        list: a list of engine names
+        names: list
+            a list of engine names
         """
         return self._engine_extensions.keys()

--- a/simphony/engine/extension.py
+++ b/simphony/engine/extension.py
@@ -197,8 +197,24 @@ class EngineManager(object):
                                             engine_interface)
         else:
             raise EngineManagerException(
-                'Invalid engine name: %s' % engine_name)
+                'Invalid engine name: %s. Available engines are %s'
+                % (engine_name, self.get_supported_engine_names()))
 
     def get_supported_engines(self):
-        """Show a list of supported engines."""
+        """Get metadata about supported engines.
+
+        Returns
+        -------
+        list: a list of EngineMetadata objects
+        """
+        return list(self._engine_extensions.values())
+
+    def get_supported_engine_names(self):
+        """Show a list of supported engines.
+
+        Returns
+        -------
+        list: a list of engine names
+        """
         return self._engine_extensions.keys()
+

--- a/simphony/engine/extension.py
+++ b/simphony/engine/extension.py
@@ -1,0 +1,201 @@
+"""Engine extension tools and classes."""
+import inspect
+from abc import ABCMeta, abstractmethod
+from enum import Enum
+
+
+class EngineInterface(Enum):
+    """Represents an available interface to an engine.
+
+    An interface is either internal or fileio. Internal interfaces use
+    a python package or a shared library to talk to the underlying engine.
+    FileIO, on the other hand, uses input/output files to interact with
+    an engine executable.
+    """
+    Internal = 'internal'
+    FileIO = 'fileio'
+
+
+class EngineManagerException(Exception):
+    """Any excpetion related to engine manager."""
+    pass
+
+
+class EngineFeatureMetadata(object):
+    """Represents a set of engine features.
+
+    A feature provides a set of methods to solve a physics equation.
+
+    Parameters
+    ----------
+    physics_equation: PhysicsEquation
+      represents a physics equation
+    methods: list
+      methods to solve the equation as a list of ComputationalMethod objects
+    """
+    def __init__(self, physics_equation, methods):
+        if not physics_equation:
+            raise EngineManagerException('Physics equation must have a value.')
+        if not methods or len(methods) == 0:
+            raise EngineManagerException('At least one method must be provided.')
+        self.physics_equation = physics_equation
+        self.methods = methods
+
+
+class EngineMetadata(object):
+    """Data structure to represent engine metadata.
+
+    This class represents one supported engine along with its features.
+
+    Parameters
+    ----------
+    name: str
+      fixed name of a support engine to be used in user's data, i.e. key.
+    features: list
+      features of this engine as a list of EngineFeatureMetadata objects
+    interfaces: list
+      supported engine interfaces as a list of EngineInterface enums
+
+    """
+    def __init__(self, name, features, interfaces):
+        self.name = name
+        self.features = features
+        self.interfaces = interfaces
+
+
+class ABCEngineExtension(object):
+    """Base class for all engine extensions."""
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def get_supported_engines(self):
+        """Get metadata about supported engines.
+
+        Returns
+        -------
+        list: a list of EngineMetadata objects
+        """
+
+    @abstractmethod
+    def create_wrapper(self, cuds, engine_name, engine_interface):
+        """Creates a wrapper to the requested engine.
+
+        Parameters
+        ----------
+        cuds: CUDS
+          CUDS computational model data
+        engine_name: str
+          name of the engine, must be supported by this extension
+        engine_interface: EngineInterface
+          the interface to interact with engine
+
+        Returns
+        -------
+        ABCEngineExtension: A wrapper configured with cuds and ready to run
+        """
+
+    @staticmethod
+    def create_engine_metadata(name, features, interfaces):
+        """Factory method to create engine metadata.
+
+        Parameters
+        ----------
+        name: str
+          fixed name of a support engine to be used in user's data, i.e. key.
+        features: list
+          features of this engine as a list of EngineFeatureMetadata objects
+        interfaces: list
+          supported engine interfaces as a list of EngineInterface enums
+
+        Returns
+        -------
+        EngineMetadata: a loaded engine metadata object
+        """
+        return EngineMetadata(name, features, interfaces)
+
+    @staticmethod
+    def create_engine_metadata_feature(physics_equation, methods):
+        """Factory method to create engine metadata feature.
+
+        Parameters
+        ----------
+        physics_equation: PhysicsEquation
+          represents a physics equation
+        methods: list
+          methods to solve the equation as a list of ComputationalMethod objects
+
+        Return
+        ------
+        EngineFeatureMetadata: a loaded engine metadata feature object
+        """
+        return EngineFeatureMetadata(physics_equation, methods)
+
+
+class EngineManager(object):
+    """Controller class to keep track of engine extensions."""
+    def __init__(self):
+        self._engine_extensions = {}
+
+    def load_metadata(self, plugin):
+        """Load existing engine extensions into the manager.
+
+        This method inspects the given module and looks for ABCEngineExtension
+         subclasses. If provided, will instantiate and keep them for further
+         interactions with corresponding engines.
+
+        plugin: module
+          A python module provided by an extension
+        """
+        if not inspect.ismodule(plugin):
+            raise EngineManagerException('The provided object is not a module: %s' % plugin)
+
+        for name, value in inspect.getmembers(plugin, inspect.isclass):
+            if not inspect.isabstract(value) and\
+                    issubclass(value, ABCEngineExtension):
+                # Load the corresponding engine extension
+                extension = value()
+                if not isinstance(extension, ABCEngineExtension):
+                    raise ValueError('Expected ABCEngineExtension, got %s' %
+                                     extension)
+                self.add_extension(extension)
+
+    def add_extension(self, extension):
+        """Add an extension to the context.
+
+        Parameters
+        ----------
+        extension: ABCEngineExtension
+          an extension that has knowledge about its own engines.
+        """
+        for engine in extension.get_supported_engines():
+            if engine.name in self._engine_extensions:
+                raise Exception('There is already an extension registered'
+                                ' for %s engine.' % engine.name)
+
+            # We keep this extension because it knows how to create wrappers for
+            # the given engine. It is our interaction point with its engines.
+            self._engine_extensions[engine.name] = extension
+
+    def create_wrapper(self, cuds, engine_name, engine_interface=None):
+        """Create a wrapper to the given engine.
+
+        Parameters
+        ----------
+        cuds: CUDS
+            A cuds object which contains model information.
+        engine_name: str
+            Name of the underlying engine to launch the simulation with.
+        engine_interface: EngineInterface
+            The interface to the engine, internal or fileio.
+        """
+        if engine_name in self._engine_extensions:
+            extension = self._engine_extensions[engine_name]
+            return extension.create_wrapper(cuds,
+                                            engine_name,
+                                            engine_interface)
+        else:
+            raise EngineManagerException('Invalid engine name: %s' % engine_name)
+
+    def get_supported_engines(self):
+        """Show a list of supported engines."""
+        return self._engine_extensions.keys()

--- a/simphony/engine/extension.py
+++ b/simphony/engine/extension.py
@@ -37,7 +37,8 @@ class EngineFeatureMetadata(object):
         if not physics_equation:
             raise EngineManagerException('Physics equation must have a value.')
         if not methods or len(methods) == 0:
-            raise EngineManagerException('At least one method must be provided.')
+            raise \
+                EngineManagerException('At least one method must be provided.')
         self.physics_equation = physics_equation
         self.methods = methods
 
@@ -122,7 +123,7 @@ class ABCEngineExtension(object):
         physics_equation: PhysicsEquation
           represents a physics equation
         methods: list
-          methods to solve the equation as a list of ComputationalMethod objects
+          ComputationalMethod objects to solve the equation
 
         Return
         ------
@@ -147,7 +148,8 @@ class EngineManager(object):
           A python module provided by an extension
         """
         if not inspect.ismodule(plugin):
-            raise EngineManagerException('The provided object is not a module: %s' % plugin)
+            raise EngineManagerException(
+                'The provided object is not a module: %s' % plugin)
 
         for name, value in inspect.getmembers(plugin, inspect.isclass):
             if not inspect.isabstract(value) and\
@@ -172,8 +174,8 @@ class EngineManager(object):
                 raise Exception('There is already an extension registered'
                                 ' for %s engine.' % engine.name)
 
-            # We keep this extension because it knows how to create wrappers for
-            # the given engine. It is our interaction point with its engines.
+            # This extension knows how to create wrappers for the given engine.
+            # It is our interaction point with its engines.
             self._engine_extensions[engine.name] = extension
 
     def create_wrapper(self, cuds, engine_name, engine_interface=None):
@@ -194,7 +196,8 @@ class EngineManager(object):
                                             engine_name,
                                             engine_interface)
         else:
-            raise EngineManagerException('Invalid engine name: %s' % engine_name)
+            raise EngineManagerException(
+                'Invalid engine name: %s' % engine_name)
 
     def get_supported_engines(self):
         """Show a list of supported engines."""

--- a/simphony/engine/extension.py
+++ b/simphony/engine/extension.py
@@ -217,4 +217,3 @@ class EngineManager(object):
         list: a list of engine names
         """
         return self._engine_extensions.keys()
-

--- a/simphony/engine/tests/test_engine_metadata.py
+++ b/simphony/engine/tests/test_engine_metadata.py
@@ -81,7 +81,8 @@ class TestEngineManager(unittest.TestCase):
         self.assertEqual(len(supported), 1)
 
     def test_assert_duplicate_engine(self):
-        self.assertRaises(Exception, self.manager.load_metadata, sys.modules[__name__])
+        self.assertRaises(Exception,
+                          self.manager.load_metadata, sys.modules[__name__])
 
     def test_add_extension(self):
         cls = get_example_engine_extension()
@@ -91,13 +92,16 @@ class TestEngineManager(unittest.TestCase):
         self.assertEqual(len(supported), 2)
 
     def test_create_wrapper(self):
-        self.assertRaises(EngineManagerException, self.manager.create_wrapper, None, 'EXAMPLE2')
+        self.assertRaises(EngineManagerException,
+                          self.manager.create_wrapper, None, 'EXAMPLE2')
         # Example is a dummpy engine. It does not have any wrapper.
         self.assertEqual(self.manager.create_wrapper(None, 'EXAMPLE1'), None)
 
     def test_non_module_load(self):
-        class MyClass:pass
-        self.assertRaises(EngineManagerException, self.manager.load_metadata, MyClass)
+        class MyClass:
+            pass
+        self.assertRaises(EngineManagerException,
+                          self.manager.load_metadata, MyClass)
 
 
 class TestEngineFeature(unittest.TestCase):
@@ -109,8 +113,10 @@ class TestEngineFeature(unittest.TestCase):
         pass
 
     def test_init(self):
-        self.assertRaises(EngineManagerException, EngineFeatureMetadata, None, None)
-        self.assertRaises(EngineManagerException, EngineFeatureMetadata, None, [])
+        self.assertRaises(EngineManagerException,
+                          EngineFeatureMetadata, None, None)
+        self.assertRaises(EngineManagerException,
+                          EngineFeatureMetadata, None, [])
 
 
 class TestEngineMetadata(unittest.TestCase):

--- a/simphony/engine/tests/test_engine_metadata.py
+++ b/simphony/engine/tests/test_engine_metadata.py
@@ -1,0 +1,128 @@
+"""Tests regarding loading engine's metadata."""
+import sys
+import unittest
+
+import simphony.engine as engine_api
+from simphony.engine import ABCEngineExtension, EngineInterface
+from simphony.engine.extension import EngineManager, EngineManagerException
+from simphony.engine.extension import EngineFeatureMetadata, EngineMetadata
+
+
+class _Example1(ABCEngineExtension):
+    def get_supported_engines(self):
+        example_engine = \
+            self.create_engine_metadata('EXAMPLE1',
+                                        None,
+                                        [EngineInterface.Internal,
+                                         EngineInterface.FileIO])
+
+        return [example_engine]
+
+    def create_wrapper(self, cuds, engine_name, engine_interface):
+        if engine_name == 'EXAMPLE1':
+            pass
+        else:
+            raise Exception('Only EXAMPLE1 engine is supported. '
+                            'Unsupported eninge: %s', engine_name)
+
+
+def get_example_engine_extension():
+    class _Example2(ABCEngineExtension):
+        def get_supported_engines(self):
+            example_engine = \
+                self.create_engine_metadata('EXAMPLE2',
+                                            None,
+                                            [EngineInterface.Internal,
+                                             EngineInterface.FileIO])
+
+            return [example_engine]
+
+        def create_wrapper(self, cuds, engine_name, engine_interface):
+            if engine_name == 'EXAMPLE2':
+                pass
+            else:
+                raise Exception('Only EXAMPLE2 engine is supported. '
+                                'Unsupported eninge: %s', engine_name)
+    return _Example2
+
+
+class TestEnginePublicAPI(unittest.TestCase):
+    """Test everything engine metadata."""
+    def setUp(self):
+        self.manager = engine_api._ENGINE_MANAGER
+
+    def tearDown(self):
+        pass
+
+    def test_get_supported_engines(self):
+        supported = engine_api.get_supported_engines()
+        assert(isinstance(supported, list))
+
+    def test_create_wrapper(self):
+        pass
+
+
+class TestEngineManager(unittest.TestCase):
+    """Test everything engine metadata."""
+    def setUp(self):
+        self.manager = EngineManager()
+        self.manager.load_metadata(sys.modules[__name__])
+
+    def tearDown(self):
+        pass
+
+    def test_get_supported_engines(self):
+        supported = self.manager.get_supported_engines()
+        self.assertIn('EXAMPLE1', supported)
+        self.assertNotIn('LAMMPS', supported)
+
+    def test_engine_count(self):
+        supported = self.manager.get_supported_engines()
+        self.assertEqual(len(supported), 1)
+
+    def test_assert_duplicate_engine(self):
+        self.assertRaises(Exception, self.manager.load_metadata, sys.modules[__name__])
+
+    def test_add_extension(self):
+        cls = get_example_engine_extension()
+        self.manager.add_extension(cls())
+        supported = self.manager.get_supported_engines()
+        self.assertIn('EXAMPLE2', supported)
+        self.assertEqual(len(supported), 2)
+
+    def test_create_wrapper(self):
+        self.assertRaises(EngineManagerException, self.manager.create_wrapper, None, 'EXAMPLE2')
+        # Example is a dummpy engine. It does not have any wrapper.
+        self.assertEqual(self.manager.create_wrapper(None, 'EXAMPLE1'), None)
+
+    def test_non_module_load(self):
+        class MyClass:pass
+        self.assertRaises(EngineManagerException, self.manager.load_metadata, MyClass)
+
+
+class TestEngineFeature(unittest.TestCase):
+    """Test everything engine metadata."""
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_init(self):
+        self.assertRaises(EngineManagerException, EngineFeatureMetadata, None, None)
+        self.assertRaises(EngineManagerException, EngineFeatureMetadata, None, [])
+
+
+class TestEngineMetadata(unittest.TestCase):
+    """Test everything engine metadata."""
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_init(self):
+        m = EngineMetadata('myengine', None, EngineInterface.Internal)
+        self.assertEqual(m.name, 'myengine')
+        self.assertEqual(m.features, None)
+        self.assertEqual(m.interfaces, EngineInterface.Internal)

--- a/simphony/engine/tests/test_engine_metadata.py
+++ b/simphony/engine/tests/test_engine_metadata.py
@@ -3,12 +3,53 @@ import sys
 import unittest
 
 import simphony.engine as engine_api
+from simphony import CUDS
+from simphony.cuds.abc_modeling_engine import ABCModelingEngine
 from simphony.engine import ABCEngineExtension, EngineInterface
 from simphony.engine.extension import EngineManager, EngineManagerException
 from simphony.engine.extension import EngineFeatureMetadata, EngineMetadata
 
 
+class DummyEngine(ABCModelingEngine):
+    def __init__(self, *args, **kwargs):
+        self._cuds = kwargs.get('cuds')
+        self._load_cuds()
+
+    def _load_cuds(self):
+        pass
+
+    def get_cuds(self):
+        return self._cuds
+
+    def run(self):
+        pass
+
+    def add_dataset(self, container):
+        pass
+
+    def remove_dataset(self, name):
+        pass
+
+    def get_dataset(self, name):
+        pass
+
+    def get_dataset_names(self):  # pragma: no cover
+        pass
+
+    def iter_datasets(self, names=None):  # pragma: no cover
+        pass
+
+
+class DummyEngine1(DummyEngine):
+    pass
+
+
+class DummyEngine2(DummyEngine):
+    pass
+
+
 class _Example1(ABCEngineExtension):
+    """A dummy engine extension."""
     def get_supported_engines(self):
         example_engine = \
             self.create_engine_metadata('EXAMPLE1',
@@ -19,14 +60,14 @@ class _Example1(ABCEngineExtension):
         return [example_engine]
 
     def create_wrapper(self, cuds, engine_name, engine_interface):
-        if engine_name == 'EXAMPLE1':
-            pass
-        else:
+        if engine_name != 'EXAMPLE1':
             raise Exception('Only EXAMPLE1 engine is supported. '
                             'Unsupported eninge: %s', engine_name)
+        return DummyEngine1(cuds=cuds)
 
 
 def get_example_engine_extension():
+    """A dummy engine extension."""
     class _Example2(ABCEngineExtension):
         def get_supported_engines(self):
             example_engine = \
@@ -34,47 +75,35 @@ def get_example_engine_extension():
                                             None,
                                             [EngineInterface.Internal,
                                              EngineInterface.FileIO])
-
             return [example_engine]
 
         def create_wrapper(self, cuds, engine_name, engine_interface):
-            if engine_name == 'EXAMPLE2':
-                pass
-            else:
+            if engine_name != 'EXAMPLE2':
                 raise Exception('Only EXAMPLE2 engine is supported. '
                                 'Unsupported eninge: %s', engine_name)
+            return DummyEngine2(cuds=cuds)
     return _Example2
 
 
 class TestEnginePublicAPI(unittest.TestCase):
     """Test everything engine metadata."""
-    def setUp(self):
-        self.manager = engine_api._ENGINE_MANAGER
-
-    def tearDown(self):
-        pass
-
     def test_get_supported_engines(self):
         supported = engine_api.get_supported_engines()
+        # TODO: inspect the returned metadata
         assert(isinstance(supported, list))
-
-    def test_create_wrapper(self):
-        pass
 
 
 class TestEngineManager(unittest.TestCase):
     """Test everything engine metadata."""
     def setUp(self):
         self.manager = EngineManager()
+        # Load engines defined in this test moduel.
         self.manager.load_metadata(sys.modules[__name__])
-
-    def tearDown(self):
-        pass
 
     def test_get_supported_engines(self):
         supported = self.manager.get_supported_engine_names()
         self.assertIn('EXAMPLE1', supported)
-        self.assertNotIn('LAMMPS', supported)
+        self.assertNotIn('EXAMPLE2', supported)
 
     def test_engine_count(self):
         supported = self.manager.get_supported_engine_names()
@@ -92,10 +121,23 @@ class TestEngineManager(unittest.TestCase):
         self.assertEqual(len(supported), 2)
 
     def test_create_wrapper(self):
-        self.assertRaises(EngineManagerException,
-                          self.manager.create_wrapper, None, 'EXAMPLE2')
-        # Example is a dummpy engine. It does not have any wrapper.
-        self.assertEqual(self.manager.create_wrapper(None, 'EXAMPLE1'), None)
+        cuds = CUDS()
+        example1 = \
+            self.manager.create_wrapper(cuds,
+                                        'EXAMPLE1',
+                                        engine_api.EngineInterface.Internal)
+        self.assertIsInstance(example1, DummyEngine1)
+        self.assertEqual(cuds, example1.get_cuds())
+
+        # Explicitely add example2 engine
+        cls = get_example_engine_extension()
+        self.manager.add_extension(cls())
+        example2 = \
+            self.manager.create_wrapper(cuds,
+                                        'EXAMPLE2',
+                                        engine_api.EngineInterface.Internal)
+        self.assertIsInstance(example2, DummyEngine2)
+        self.assertEqual(cuds, example2.get_cuds())
 
     def test_non_module_load(self):
         class MyClass:
@@ -106,12 +148,6 @@ class TestEngineManager(unittest.TestCase):
 
 class TestEngineFeature(unittest.TestCase):
     """Test everything engine metadata."""
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_init(self):
         self.assertRaises(EngineManagerException,
                           EngineFeatureMetadata, None, None)
@@ -121,12 +157,6 @@ class TestEngineFeature(unittest.TestCase):
 
 class TestEngineMetadata(unittest.TestCase):
     """Test everything engine metadata."""
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_init(self):
         m = EngineMetadata('myengine', None, EngineInterface.Internal)
         self.assertEqual(m.name, 'myengine')

--- a/simphony/engine/tests/test_engine_metadata.py
+++ b/simphony/engine/tests/test_engine_metadata.py
@@ -72,12 +72,12 @@ class TestEngineManager(unittest.TestCase):
         pass
 
     def test_get_supported_engines(self):
-        supported = self.manager.get_supported_engines()
+        supported = self.manager.get_supported_engine_names()
         self.assertIn('EXAMPLE1', supported)
         self.assertNotIn('LAMMPS', supported)
 
     def test_engine_count(self):
-        supported = self.manager.get_supported_engines()
+        supported = self.manager.get_supported_engine_names()
         self.assertEqual(len(supported), 1)
 
     def test_assert_duplicate_engine(self):
@@ -87,7 +87,7 @@ class TestEngineManager(unittest.TestCase):
     def test_add_extension(self):
         cls = get_example_engine_extension()
         self.manager.add_extension(cls())
-        supported = self.manager.get_supported_engines()
+        supported = self.manager.get_supported_engine_names()
         self.assertIn('EXAMPLE2', supported)
         self.assertEqual(len(supported), 2)
 


### PR DESCRIPTION
In this PR we add a number of new features to SimPhoNy as part of #281 #285 #277 :

- [x] - Add CUDS class. The high level container for any CUDS component
- [x] - Modify engine base class to accept CUDS
- [x] - Add Simulation class. Think of it as a general wrapper
- [x] - Add base for engine extensions
- [x] - Load engine extenion metadata upon importing simphony
- [x] - Add query functions to get info about available engines
- [x] - Add store classes to hold information about StateData
- [x] - Add engine metadata tests
- [x] - Add simulation tests 