### PR TITLE
Feature: Add support for restricted cuba key in DataContainer

### DIFF
--- a/simphony/core/data_container.py
+++ b/simphony/core/data_container.py
@@ -1,4 +1,4 @@
-from .cuba import CUBA
+from simphony.core.cuba import CUBA
 
 
 class DataContainer(dict):

--- a/simphony/core/data_container.py
+++ b/simphony/core/data_container.py
@@ -103,7 +103,8 @@ class DataContainer(dict):
             raise ValueError(message.format(invalid_keys))
 
 
-def create_data_container(restricted_keys):
+def create_data_container(restricted_keys,
+                          class_name='RestrictedDataContainer'):
     ''' Create a DataContainer subclass with the given
     restricted keys
 
@@ -118,6 +119,9 @@ def create_data_container(restricted_keys):
     restricted_keys : sequence
         CUBA IntEnum
 
+    class_name : str
+        Name of the returned class
+
     Returns
     -------
     RestrictedDataContainer : DataContainer
@@ -125,7 +129,9 @@ def create_data_container(restricted_keys):
 
     Examples
     --------
-    >>> container = create_data_container((CUBA.NAME, CUBA.VELOCITY))()
+    >>> RestrictedDataContainer = create_data_container((CUBA.NAME,
+                                                         CUBA.VELOCITY))
+    >>> container = RestrictedDataContainer()
     >>> container.restricted_keys
     frozenset({<CUBA.VELOCITY: 55>, <CUBA.NAME: 61>})
     >>> container[CUBA.NAME] = 'name'
@@ -139,7 +145,7 @@ def create_data_container(restricted_keys):
 
     mapping = {key.name: key for key in restricted_keys}
 
-    new_class = type('RestrictedDataContainer', (DataContainer,),
+    new_class = type(class_name, (DataContainer,),
                      {'__doc__': DataContainer.__doc__,
                       '__slots__': (),
                       'restricted_keys': frozenset(restricted_keys),

--- a/simphony/core/data_container.py
+++ b/simphony/core/data_container.py
@@ -129,17 +129,9 @@ def create_data_container(restricted_keys):
     if any(not isinstance(key, CUBA) for key in restricted_keys):
         raise ValueError('All restricted keys should be CUBA IntEnum')
 
-    template = '''class RestrictedDataContainer(DataContainer):
-    __doc__ = DataContainer.__doc__
-    __slots__ = ()
-    restricted_keys = restricted_keys
-    _restricted_mapping = mapping
-    '''
-
     mapping = {key.name: key for key in restricted_keys}
 
-    namespace = dict(DataContainer=DataContainer,
-                     restricted_keys=frozenset(restricted_keys),
-                     mapping=mapping)
-    exec template in namespace
-    return namespace['RestrictedDataContainer']
+    return type('RestrictedDataContainer', (DataContainer,),
+                {'__doc__': DataContainer.__doc__,
+                 'restricted_keys': frozenset(restricted_keys),
+                 '_restricted_mapping': mapping})

--- a/simphony/core/tests/test_data_container.py
+++ b/simphony/core/tests/test_data_container.py
@@ -1,3 +1,5 @@
+import cPickle
+from io import BytesIO
 import unittest
 
 from simphony.core.cuba import CUBA
@@ -149,6 +151,12 @@ class TestDataContainer(unittest.TestCase):
             container[100] = 29
 
 
+# Create a container class here for testing pickling
+# As with all dynamically created classes, it needs to be
+# properly named in a module in order for pickling to work
+RestrictedDataContainer = create_data_container(CUBA)
+
+
 class TestRestrictedDataContainer(unittest.TestCase):
 
     def setUp(self):
@@ -187,6 +195,21 @@ class TestRestrictedDataContainer(unittest.TestCase):
     def test_error_with_non_cuba_keys(self):
         with self.assertRaises(ValueError):
             create_data_container((1, 2))
+
+    def test_data_container_can_be_pickled(self):
+        # Create a container with data
+        container = RestrictedDataContainer()
+        for key in CUBA:
+            container[key] = key+3
+
+        # Pickle and write to a buffer
+        stream = BytesIO()
+        cPickle.dump(container, stream)
+        stream.seek(0)
+
+        # Restore the data
+        pickled_data = cPickle.load(stream)
+        self.assertDictEqual(pickled_data, container)
 
 
 if __name__ == '__main__':

--- a/simphony/core/tests/test_data_container.py
+++ b/simphony/core/tests/test_data_container.py
@@ -184,6 +184,10 @@ class TestRestrictedDataContainer(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_data_container(self.valid_keys)(data)
 
+    def test_error_with_non_cuba_keys(self):
+        with self.assertRaises(ValueError):
+            create_data_container((1, 2))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In order to replicate the keyword checking in `MaterialRelation` (https://github.com/simphony/simphony-common/blob/master/simphony/cuds/material_relations/material_relation.py#L107) for all the generated classes from simphony-metadata, it would be more effective if the checking is done at the `DataContainer `level.

For example:
```
>>> from simphony.core.data_container import create_data_container
>>> container = create_data_container((CUBA.NAME, CUBA.VELOCITY))()
>>> container.restricted_keys
frozenset({<CUBA.VELOCITY: 55>, <CUBA.NAME: 61>})
>>> container[CUBA.NAME] = 'name'
>>> container[CUBA.POSITION] = (1.0, 1.0, 1.0)
...
ValueError: Key <CUBA.POSITION: 119> is not in the supported CUBA keywords
```

Performance of the DataContainer is basically the same to the one we have now.  Benchmark:
```
Initialization:
dict: 1000000 calls, best of 5 repeats: 0.000001 sec per call
DataContainer: 100000 calls, best of 5 repeats: 0.000011 sec per call  (was 0.000010)
dict == DataContainer True

Iterations:
dict: 1000000 calls, best of 5 repeats: 0.000001 sec per call
DataContainer: 1000000 calls, best of 5 repeats: 0.000001 sec per call  (same)

getitem access:
dict: 100000 calls, best of 5 repeats: 0.000007 sec per call
DataContainer: 100000 calls, best of 5 repeats: 0.000012 sec per call  (same)
dict == DataContainer True

setitem with CUBA keys:
dict: 10000 calls, best of 5 repeats: 0.000024 sec per call
DataContainer: 10000 calls, best of 5 repeats: 0.000061 sec per call  (was 0.000058)
dict == DataContainer True
```
(Running with Ubuntu 12 on a VM with 1 core, 2.5GHz, 4GB RAM)

Please consider this as a proposal and please comment, review or propose alternatives.
