### PR TITLE
Upgrade pip on appvayor install.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,10 @@ init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
   - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
-    # not updating pip (using get-pip.py) due to problem
-    # with pip/wheel (https://github.com/simphony/simphony-common/issues/274)
+  - ps: $Env:pip_bootstrap = $Env:temp + "\get-pip.py"
 install:
+  - ps: (new-object net.webclient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', $Env:pip_bootstrap)
+  - ps: python $Env:pip_bootstrap
   - "%PYTHON%\\python.exe -m pip install wheel"
   - ps: pip --version
   - cmd /v:on /e:on /c ".\appveyor-install.cmd"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,9 +15,9 @@
 import sphinx.environment
 from docutils.utils import get_source_line
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, node, **kwargs):
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        self._warnfunc(msg, '%s:%s' % get_source_line(node), **kwargs)
 
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node


### PR DESCRIPTION
This PR fixes #274 by installing updated pip on appvayor. Moreover, it fixes the custom warning function in sphinx, which provides access to external images in documents.