### PR TITLE
Problem: imports in simphony.__init__ may cause import cycles

### DIFF
--- a/simphony/api.py
+++ b/simphony/api.py
@@ -12,4 +12,11 @@ For more information see: http://www.simphony-project.eu/.
 
 :copyright: (c) 2014, 2015, 2016 SimPhoNy Consortium
 :license: BSD, see LICENSE for more details.
+
+This module exports the public interface of the SimPhoNy project.
 """
+from .core import CUBA
+from .cuds import CUDS, Simulation
+
+
+__all__ = ['CUBA', 'CUDS', 'Simulation']

--- a/simphony/cuds/tests/test_cuds.py
+++ b/simphony/cuds/tests/test_cuds.py
@@ -2,7 +2,7 @@
 import unittest
 import uuid
 
-from simphony import CUDS
+from simphony.api import CUDS
 from simphony.cuds.particles import Particle, Particles
 
 

--- a/simphony/cuds/tests/test_simulation.py
+++ b/simphony/cuds/tests/test_simulation.py
@@ -2,8 +2,8 @@
 import unittest
 from mock import patch
 
-from simphony import CUDS
-from simphony import Simulation
+from simphony.api import CUDS
+from simphony.api import Simulation
 from simphony.engine import get_engine_manager
 from simphony.engine.tests.test_engine_metadata import \
     get_example_engine_extension

--- a/simphony/engine/tests/test_engine_metadata.py
+++ b/simphony/engine/tests/test_engine_metadata.py
@@ -2,7 +2,7 @@
 import unittest
 from mock import patch
 
-from simphony import CUDS
+from simphony.api import CUDS
 from simphony.cuds.abc_modeling_engine import ABCModelingEngine
 from simphony.engine import ABCEngineExtension,\
     EngineInterface, get_engine_manager, get_supported_engine_names


### PR DESCRIPTION
Solution: move public API (imports in simphony.__init__.py) to simphony.api

Close #301 