### PR TITLE
Update cuds api according to m30

### DIFF
--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -147,7 +147,15 @@ class CUDS(object):
         -------
         component: CUDSComponent
             the corresponding CUDS component or None
+
+        Raises
+        ------
+        TypeError
+            if the name is not a non empty string
         """
+        if not name:
+            raise TypeError('name must be a non empty string.')
+
         uid = self._name_to_id_map.get(name)
         return self.get_by_uid(uid)
 

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -115,16 +115,9 @@ class CUDS(object):
             raise TypeError('Not a CUDSComponent nor a dataset object: %s.' %
                             type(component))
 
-        # Do not accept items with duplicate names unless the expected
-        # behaviour is defined clearly for the following sample code:
-        # m1 = api.Material(name="item1")
-        # m2 = api.Material(name="item1")
-        # b1 = api.Box(name="item1")
-        # b2 = api.Box(name="item1")
-        # cuds.add(m1)
-        # cuds.add(m2)
-        # cuds.add(b1)
-        # cuds.add(b2)
+        # Do not accept items with duplicate names.
+        # Components/datasets with no name will be added, however
+        # it is not possible to get/remove them with `name`
         if component.name in self._name_to_id_map:
             raise ValueError('Name clash. A %s component has the same name %s'
                              % (type(self.get(component.name)),
@@ -140,8 +133,7 @@ class CUDS(object):
             self._map[component.name] = \
                 lambda key=component.name: self._dataset_store.get(key)
             # Datasets use name as id
-            if component.name not in (None, ''):
-                self._name_to_id_map[component.name] = component.name
+            self._name_to_id_map[component.name] = component.name
         else:
             # Delete existing item with the same name
             # Store the component. Any CUDS item has uid property.
@@ -149,6 +141,9 @@ class CUDS(object):
             self._map[component.uid] = \
                 lambda key=component.uid: self._store.get(key)
             # Store name for name-to-id mapping.
+            # Components with no name will are not added to the mapping
+            # and it is not possible to access them using add/remove
+            # methods. Use `get_by_uid` and `remove_by_uid` instead.
             if component.name not in (None, ''):
                 self._name_to_id_map[component.name] = component.uid
 

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -62,14 +62,6 @@ class CUDS(object):
     def uid(self):
         return self._uid
 
-    @uid.setter
-    def uid(self, value):
-        raise TypeError("uid is readonly.")
-
-    @uid.deleter
-    def uid(self):
-        raise TypeError("Can't delete uid.")
-
     @staticmethod
     def _is_dataset(obj):
         """Check if the object is a dataset."""
@@ -86,10 +78,6 @@ class CUDS(object):
     @data.setter
     def data(self, value):
         self._data = DataContainer(value)
-
-    @data.deleter
-    def data(self):
-        raise TypeError("Can't delete data.")
 
     def add(self, component):
         """Add a component to the CUDS computational model.

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -132,6 +132,9 @@ class CUDS(object):
 
         # Add datasets separately
         if self._is_dataset(component):
+            if not component.name:
+                raise TypeError('Dataset must have a name.')
+
             self._dataset_store.add(component)
             # Datasets at the moment do not have uid
             self._map[component.name] = \
@@ -193,7 +196,13 @@ class CUDS(object):
         ------
         KeyError
             if no component exists of the given name
+
+        TypeError
+            if the name is not a non empty string
         """
+        if not name:
+            raise TypeError('name must be a non empty string.')
+
         uid = self._name_to_id_map.get(name)
         self.remove_by_uid(uid)
 

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -3,6 +3,8 @@
 This module contains the classes used to represent a computational model,
 based on SimPhoNy metadata.
 """
+import uuid
+
 from .store import MemoryStateDataStore
 from .abc_particles import ABCParticles
 from .abc_lattice import ABCLattice
@@ -28,6 +30,9 @@ class CUDS(object):
     """
     def __init__(self, name=None, description=None):
 
+        # Assign unique ID
+        self._uid = uuid.uuid4()
+
         # Add name
         self.name = name
 
@@ -52,6 +57,18 @@ class CUDS(object):
 
         # Another map to keep a mapping between names and ids
         self._name_to_id_map = {}
+
+    @property
+    def uid(self):
+        return self._uid
+
+    @uid.setter
+    def uid(self, value):
+        raise TypeError("uid is readonly.")
+
+    @uid.deleter
+    def uid(self):
+        raise TypeError("Can't delete uid.")
 
     @staticmethod
     def _is_dataset(obj):

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -120,7 +120,8 @@ class CUDS(object):
             self._map[component.name] = \
                 lambda key=component.name: self._dataset_store.get(key)
             # Datasets use name as id
-            self._name_to_id_map[component.name] = component.name
+            if component.name not in (None, ''):
+                self._name_to_id_map[component.name] = component.name
         else:
             # Delete existing item with the same name
             # Store the component. Any CUDS item has uid property.
@@ -128,7 +129,8 @@ class CUDS(object):
             self._map[component.uid] = \
                 lambda key=component.uid: self._store.get(key)
             # Store name for name-to-id mapping.
-            self._name_to_id_map[component.name] = component.uid
+            if component.name not in (None, ''):
+                self._name_to_id_map[component.name] = component.uid
 
     def get(self, name):
         """Get the corresponding component from the CUDS computational model.
@@ -203,7 +205,8 @@ class CUDS(object):
         else:
             del self._store[uid]
         # Delete object key from the mappings
-        del self._name_to_id_map[component.name]
+        if component.name in self._name_to_id_map:
+            del self._name_to_id_map[component.name]
 
     # This should be query method
     def iter(self, component_type):

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -82,8 +82,7 @@ class CUDS(object):
     def add(self, component):
         """Add a component to the CUDS computational model.
 
-        This will replace any existing value with the same `uid`
-        or `name`.
+        This will replace any existing value with the same `uid`.
 
         Parameters
         ----------
@@ -95,7 +94,7 @@ class CUDS(object):
         TypeError
             if the component is not a CUDS component
         ValueError
-            if a component already exists
+            if a component with the same name already exists
         """
         # Only accept CUDSComponent subclasses and datasets
         if not (isinstance(component, api.CUDSComponent) or
@@ -107,8 +106,9 @@ class CUDS(object):
         # Components/datasets with no name will be added, however
         # it is not possible to get/remove them with `name`
         if component.name in self._name_to_id_map:
-            raise ValueError('Name clash. A %s component has the same name %s'
-                             % (type(self.get(component.name)),
+            raise ValueError('Name clash. Component with uid `%s`'
+                             ' is already named `%s`'
+                             % (self._name_to_id_map[component.name],
                                 component.name))
 
         # Add datasets separately

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -3,16 +3,14 @@
 This module contains the classes used to represent a computational model,
 based on SimPhoNy metadata.
 """
-import uuid
-
-from ..core import DataContainer
 from .store import MemoryStateDataStore
 from .abc_particles import ABCParticles
 from .abc_lattice import ABCLattice
 from .abc_mesh import ABCMesh
+from .meta import api
+from ..core import DataContainer
 
 
-# IDEA: add consistency check handlers/instances to the CUDS class (dynamic).
 class CUDS(object):
     """Common Universal Data Structure, i.e. CUDS computational model.
 
@@ -20,8 +18,21 @@ class CUDS(object):
     a computational model. Having the data provided by this class, one should
     be able to start a new computational model based on that with no extra
     information.
+
+    Parameters
+    ----------
+    name: str
+        Name of this CUDS
+    description: str
+        More information about this CUDS
     """
-    def __init__(self):
+    def __init__(self, name=None, description=None):
+
+        # Add name
+        self.name = name
+
+        # Add description
+        self.description = description
 
         # Add datasets to memory datastore by default
         self._dataset_store = MemoryStateDataStore()
@@ -39,19 +50,16 @@ class CUDS(object):
         # that will return the corresponding value.
         self._map = {}
 
-    @staticmethod
-    def _is_cuds_component(obj):
-        """Check whether the object is a CUDS component."""
-        # When I see a bird that walks like a duck and swims like a duck
-        # and quacks like a duck, I call that bird a duck
-        # TODO: replace with metadata type checks
-        return all([hasattr(obj, 'name'),
-                    hasattr(obj, 'data')])
+        # Another map to keep a mapping between names and ids
+        self._name_to_id_map = {}
 
     @staticmethod
     def _is_dataset(obj):
         """Check if the object is a dataset."""
-        return isinstance(obj, (ABCParticles, ABCLattice, ABCMesh))
+        return isinstance(obj, (ABCParticles,
+                                ABCLattice,
+                                ABCMesh,
+                                api.DataSet))
 
     @property
     def data(self):
@@ -59,99 +67,143 @@ class CUDS(object):
         return DataContainer(self._data)
 
     @data.setter
-    def data_setter(self, value):
+    def data(self, value):
         self._data = DataContainer(value)
+
+    @data.deleter
+    def data(self):
+        raise TypeError("Can't delete data.")
 
     def add(self, component):
         """Add a component to the CUDS computational model.
 
-        If the component has `uid` attribute but that value is
-        None, a new uuid will be created and assigned to the
-        component after the component is successfully added
-        to the CUDS computational model.
+        This will replace any existing value with the same `uid`
+        or `name`.
 
         Parameters
         ----------
         component: CUDSComponent
-            a component of CUDS, reflecting SimPhoNy metadata
+            a CUDS component according to the SimPhoNy metadata
 
         Raises
         ------
         TypeError
-            if component is not a CUDS component
-
+            if the component is not a CUDS component
         ValueError
-            if the component is already added
+            if a component already exists
         """
-        # Check if the object is valid
-        if not self._is_cuds_component(component):
-            raise TypeError('Not a CUDS component.')
+        # Only accept CUDSComponent subclasses and datasets
+        if not (isinstance(component, api.CUDSComponent) or
+                self._is_dataset(component)):
+            raise TypeError('Not a CUDSComponent nor a dataset object: %s.' %
+                            type(component))
 
-        # FIXME: what if component.uui was defined before adding the
-        # component and it is not an instance of uuid.UUID,
-        # should we check for it, somewhere in this function?
-
-        try:
-            component_id = component.uid
-        except AttributeError:
-            # Datasets (ABCParticles, ABCLattice, ABCMesh) do not
-            # have a uid attibute
-            component_id = component.name
-        else:
-            # if the uuid is not defined, create a new one here
-            if component_id is None:
-                component_id = uuid.uuid4()
+        # Do not accept items with duplicate names unless the expected
+        # behaviour is defined clearly for the following sample code:
+        # m1 = api.Material(name="item1")
+        # m2 = api.Material(name="item1")
+        # b1 = api.Box(name="item1")
+        # b2 = api.Box(name="item1")
+        # cuds.add(m1)
+        # cuds.add(m2)
+        # cuds.add(b1)
+        # cuds.add(b2)
+        if component.name in self._name_to_id_map:
+            raise ValueError('Name clash. A %s component has the same name %s'
+                             % (type(self.get(component.name)),
+                                component.name))
 
         # Add datasets separately
         if self._is_dataset(component):
             self._dataset_store.add(component)
-            # Datasets have a uuid field called uid
+            # Datasets at the moment do not have uid
             self._map[component.name] = \
                 lambda key=component.name: self._dataset_store.get(key)
+            # Datasets use name as id
+            self._name_to_id_map[component.name] = component.name
         else:
-            # Store the component. Any cuds item has uuid property.
-            self._store[component_id] = component
-            self._map[component_id] = \
-                lambda key=component_id: self._store.get(key)
+            # Delete existing item with the same name
+            # Store the component. Any CUDS item has uid property.
+            self._store[component.uid] = component
+            self._map[component.uid] = \
+                lambda key=component.uid: self._store.get(key)
+            # Store name for name-to-id mapping.
+            self._name_to_id_map[component.name] = component.uid
 
-        # If the component already has a defined uid, this just reassigns
-        # the same value.  If the component.uuid is originaly None, this
-        # assigns the new uid to the component.uid
-        # Only do so after successfully adding the component
-        if hasattr(component, "uid"):
-            component.uid = component_id
-
-    def get(self, component_id):
-        """Gets a component from the CUDS computational model.
+    def get(self, name):
+        """Get the corresponding component from the CUDS computational model.
 
         Parameters
         ----------
-        component_id: uuid.UUID
-            key of a CUDS component
+        name: str
+            name of the component
 
         Returns
         -------
         component: CUDSComponent
-            a cuds component
+            the corresponding CUDS component or None
         """
-        if component_id in self._map:
-            return self._map[component_id]()
+        uid = self._name_to_id_map.get(name)
+        return self.get_by_uid(uid)
 
-    def remove(self, component_id):
-        """Removes a component from the CUDS computational model.
+    def get_by_uid(self, uid):
+        """Get the corresponding component from the CUDS computational model.
 
         Parameters
         ----------
-        component_id: uuid.UUID
-            a component of CUDS, reflecting SimPhoNy metadata
+        uid: uuid.UUID
+            uid of the component
+
+        Returns
+        -------
+        component: CUDSComponent
+            the corresponding CUDS component
         """
-        component = self.get(component_id)
+        if uid in self._map:
+            return self._map[uid]()
+
+    def remove(self, name):
+        """Remove the corresponding component from the CUDS computational model.
+
+        Parameters
+        ----------
+        name: str
+            name of the component to be removed
+
+        Raises
+        ------
+        KeyError
+            if no component exists of the given name
+        """
+        uid = self._name_to_id_map.get(name)
+        self.remove_by_uid(uid)
+
+        # Delete object's key from the mapping
+        if name in self._name_to_id_map:
+            del self._name_to_id_map[name]
+
+    def remove_by_uid(self, uid):
+        """Remove the corresponding component from the CUDS computational model.
+
+        Parameters
+        ----------
+        uid: uuid.UUID
+            uid of the component to be removed
+
+        Raises
+        ------
+        KeyError
+            if no component exists of the given uid
+        """
+        component = self.get_by_uid(uid)
         if not component:
-            raise KeyError('%s' % component_id)
+            raise KeyError('No component exists for %s' % uid)
         if self._is_dataset(component):
             self._dataset_store.remove(component.name)
         else:
-            del self._store[component_id]
+            del self._store[uid]
+        # Delete object key from the mappings
+        del self._name_to_id_map[component.name]
 
     # This should be query method
     def iter(self, component_type):
@@ -190,8 +242,8 @@ class CUDS(object):
             names of the items of the given type
         """
         if any([issubclass(component_type, ABCParticles),
-               issubclass(component_type, ABCLattice),
-               issubclass(component_type, ABCMesh)]):
+                issubclass(component_type, ABCLattice),
+                issubclass(component_type, ABCMesh)]):
             return self._dataset_store.get_names()
         else:
             return [cp.name for cp in self._store.itervalues()

--- a/simphony/cuds/model.py
+++ b/simphony/cuds/model.py
@@ -87,12 +87,12 @@ class CUDS(object):
         if not self._is_cuds_component(component):
             raise TypeError('Not a CUDS component.')
 
-        # FIXME: what if component.uuid was defined before adding the
+        # FIXME: what if component.uui was defined before adding the
         # component and it is not an instance of uuid.UUID,
         # should we check for it, somewhere in this function?
 
         try:
-            component_id = component.uuid
+            component_id = component.uid
         except AttributeError:
             # Datasets (ABCParticles, ABCLattice, ABCMesh) do not
             # have a uid attibute
@@ -116,10 +116,10 @@ class CUDS(object):
 
         # If the component already has a defined uid, this just reassigns
         # the same value.  If the component.uuid is originaly None, this
-        # assigns the new uid to the component.uuid
+        # assigns the new uid to the component.uid
         # Only do so after successfully adding the component
-        if hasattr(component, "uuid"):
-            component.uuid = component_id
+        if hasattr(component, "uid"):
+            component.uid = component_id
 
     def get(self, component_id):
         """Gets a component from the CUDS computational model.

--- a/simphony/cuds/simulation.py
+++ b/simphony/cuds/simulation.py
@@ -14,8 +14,17 @@ class Simulation(object):
         Name of the underlying engine.
     engine_interface: engine.EngineInterface
         The interface to the engine, internal or fileio.
+    name: str
+        A custom name for this simulation
+    description: str
+        More information about this simulation
     """
-    def __init__(self, cuds, engine_name, engine_interface=None):
+    def __init__(self, cuds, engine_name, engine_interface=None,
+                 name=None,
+                 description=None):
+        self.name = name
+        self.description = description
+
         if not isinstance(cuds, CUDS):
             raise TypeError('Expected CUDS but got %s' % type(cuds))
         self._cuds = cuds

--- a/simphony/cuds/store.py
+++ b/simphony/cuds/store.py
@@ -40,7 +40,7 @@ class MemoryStateDataStore(ABCStateDataStore):
     def add(self, dataset, *args, **kwargs):
         """Add the dataset to the store."""
         if dataset.name in self._datasets:
-            raise Exception('Dataset %s already exists.' % dataset.name)
+            raise ValueError('Dataset %s already exists.' % dataset.name)
         self._datasets[dataset.name] = dataset
 
     def get(self, name):

--- a/simphony/cuds/tests/test_cuds.py
+++ b/simphony/cuds/tests/test_cuds.py
@@ -1,4 +1,5 @@
 """Tests for CUDS data structure."""
+import uuid
 import unittest
 
 from simphony.api import CUDS
@@ -7,120 +8,216 @@ from simphony.cuds.particles import Particle, Particles
 
 
 class CUDSTestCase(unittest.TestCase):
-    """CUDS class tests."""
+    """Tests for CUDS container class."""
     def setUp(self):
-        self.cuds = CUDS()
+        self.named_cuds_1 = api.Box(name='mybox')
+        self.named_cuds_2 = api.Box(name='mysecondbox')
+        self.nameless_cuds_1 = api.Box()
 
-        self.dummy_component1 = api.Box(name='mybox')
-        self.dummy_component2 = api.Box(name='mysecondbox')
+    def test_cuds_uid(self):
+        c = CUDS()
 
-    def test_empty_cuds(self):
-        self.assertEqual(len(self.cuds.data), 0)
-        self.assertEqual(self.cuds.get('nonexistentkey'), None)
-        self.assertEqual(self.cuds.data, {})
-        self.assertRaises(KeyError, self.cuds.remove, 'nonexistentkey')
+        self.assertIsNotNone(c.uid)
+        self.assertIsInstance(c.uid, uuid.UUID)
 
-    def test_data(self):
-        data = self.cuds.data
-        self.assertEqual(self.cuds.data, data)
-        self.assertIsNot(self.cuds.data, data)
+    def test_named_cuds_name(self):
+        c = CUDS(name='mycuds')
 
-    def test_add_get_component(self):
-        # Add non-CUDS non-dataset object
-        self.assertRaises(TypeError, self.cuds.add, object())
-        self.cuds.add(self.dummy_component1)
-        self.assertEqual(self.cuds.get_by_uid(self.dummy_component1.uid),
-                         self.dummy_component1)
-        self.assertEqual(self.cuds.get(self.dummy_component1.name),
-                         self.dummy_component1)
+        self.assertEqual(c.name, 'mycuds')
 
-    def test_add_duplicate(self):
-        self.cuds.add(self.dummy_component1)
-        # Name is the same
-        self.assertRaises(ValueError, self.cuds.add, self.dummy_component1)
-        self.assertRaises(ValueError,
-                          self.cuds.add,
-                          api.Material(name=self.dummy_component1.name))
+    def test_nameless_cuds_name(self):
+        c = CUDS()
 
-    def test_add_dataset(self):
-        p1 = Particle()
-        p2 = Particle()
+        self.assertIsNone(c.name)
+
+    def test_descriptioned_cuds_description(self):
+        c = CUDS(description='test model')
+
+        self.assertEqual(c.description, 'test model')
+
+    def test_descriptionless_cuds_description(self):
+        c = CUDS()
+
+        self.assertIsNone(c.description)
+
+    def test_cuds_data(self):
+        c = CUDS()
+        data = c.data
+
+        self.assertEqual(c.data, data)
+        self.assertIsNot(c.data, data, msg='data is not a copy.')
+        self.assertEqual(len(c.data), 0, msg='data is not empty.')
+
+    def test_add_cuds_component(self):
+        c = CUDS()
+
+        self.assertIsNone(c.add(self.named_cuds_1))
+        self.assertIsNone(c.add(self.nameless_cuds_1))
+
+    def test_add_non_cuds_component(self):
+        c = CUDS()
+
+        self.assertRaises(TypeError, c.add, object())
+
+    def test_add_nameless_cuds_component(self):
+        c = CUDS()
+
+        self.assertIsNone(c.add(self.nameless_cuds_1))
+        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+
+    def test_add_named_cuds_component(self):
+        c = CUDS()
+
+        self.assertIsNone(c.add(self.named_cuds_1))
+        self.assertEqual(c.get(self.named_cuds_1.name),
+                         self.named_cuds_1)
+
+    def test_add_named_component_several_times(self):
+        c = CUDS()
+        c.add(self.named_cuds_1)
+
+        self.assertRaises(ValueError, c.add, self.named_cuds_1)
+
+    def test_add_nameless_component_several_times(self):
+        c = CUDS()
+        c.add(self.nameless_cuds_1)
+        c.add(self.nameless_cuds_1)
+
+        self.assertEqual(c.get_by_uid(self.nameless_cuds_1.uid),
+                         self.nameless_cuds_1)
+        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+
+    def test_get_nameless_cuds_component(self):
+        c = CUDS()
+        c.add(self.nameless_cuds_1)
+
+        self.assertEqual(c.get_by_uid(self.nameless_cuds_1.uid),
+                         self.nameless_cuds_1)
+        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+
+    def test_get_named_cuds_component(self):
+        c = CUDS()
+        c.add(self.named_cuds_1)
+
+        self.assertEqual(c.get(self.named_cuds_1.name),
+                         self.named_cuds_1)
+        self.assertEqual(c.get_by_uid(self.named_cuds_1.uid),
+                         self.named_cuds_1)
+
+    def test_add_named_dataset(self):
         ps = Particles('my particles')
-        ps.add_particles([p1, p2])
+        ps.add_particles([Particle(), Particle()])
+        c = CUDS()
+        c.add(ps)
 
-        self.cuds.add(ps)
-        self.assertEqual(self.cuds.get(ps.name), ps)
-        self.assertRaises(ValueError, self.cuds.add, ps)
+        self.assertEqual(c.get(ps.name), ps)
+        self.assertRaises(ValueError, c.add, ps)
 
-    def test_remove_component(self):
-        self.cuds.add(self.dummy_component1)
-        self.cuds.remove(self.dummy_component1.name)
-        self.assertIsNone(self.cuds.get(self.dummy_component1.name))
+    def test_add_nameless_dataset(self):
+        ps = Particles(None)
+        ps.add_particles([Particle(), Particle()])
+        c = CUDS()
 
-        self.cuds.add(self.dummy_component1)
-        self.cuds.remove_by_uid(self.dummy_component1.uid)
-        self.assertIsNone(self.cuds.get_by_uid(self.dummy_component1.uid))
+        self.assertRaises(TypeError, c.add, ps)
+
+    def test_remove_named_component_by_name(self):
+        c = CUDS()
+
+        c.add(self.named_cuds_1)
+        c.remove(self.named_cuds_1.name)
+
+        self.assertIsNone(c.get(self.named_cuds_1.name))
+
+    def test_remove_named_component_by_uid(self):
+        c = CUDS()
+        c.add(self.named_cuds_1)
+        c.remove_by_uid(self.named_cuds_1.uid)
+
+        self.assertIsNone(c.get(self.named_cuds_1.name))
+
+    def test_remove_nameless_component_by_name(self):
+        c = CUDS()
+
+        c.add(self.nameless_cuds_1)
+
+        self.assertRaises(TypeError,
+                          c.remove,
+                          self.nameless_cuds_1.name)
+
+    def test_remove_nameless_component_by_uid(self):
+        c = CUDS()
+
+        c.add(self.nameless_cuds_1)
+        c.remove_by_uid(self.nameless_cuds_1.uid)
+
+        self.assertIsNone(c.get(self.nameless_cuds_1.name))
 
     def test_remove_dataset(self):
-        p1 = Particle()
-        p2 = Particle()
         ps = Particles('my particles')
-        ps.add_particles([p1, p2])
-        self.cuds.add(ps)
-        self.cuds.remove(ps.name)
-        self.assertIsNone(self.cuds.get(ps.name))
+        ps.add_particles([Particle(), Particle()])
+        c = CUDS()
+        c.add(ps)
+        c.remove(ps.name)
 
-    def test_get_names(self):
-        p1 = Particle()
-        p2 = Particle()
-        p3 = Particle()
-        p4 = Particle()
+        self.assertIsNone(c.get(ps.name))
+
+    def test_get_dataset_names(self):
         ps1 = Particles('M1')
         ps2 = Particles('M2')
-        ps1.add_particles([p1, p2])
-        ps2.add_particles([p3, p4])
-        self.cuds.add(ps1)
-        self.cuds.add(ps2)
-        self.assertEqual(self.cuds.get_names(Particles), ['M1', 'M2'])
+        ps1.add_particles([Particle(), Particle()])
+        ps2.add_particles([Particle(), Particle()])
+        c = CUDS()
+        c.add(ps1)
+        c.add(ps2)
 
-        self.cuds.add(self.dummy_component1)
-        self.cuds.add(self.dummy_component2)
-        names = set(self.cuds.get_names(type(self.dummy_component1)))
+        self.assertEqual(c.get_names(Particles), ['M1', 'M2'])
+
+    def test_cuds_component_names(self):
+        c = CUDS()
+        c.add(self.named_cuds_1)
+        c.add(self.named_cuds_2)
+        names = set(c.get_names(type(self.named_cuds_1)))
+
         self.assertEqual(names,
-                         set([self.dummy_component1.name,
-                              self.dummy_component2.name]))
+                         set([self.named_cuds_1.name,
+                              self.named_cuds_2.name]))
 
-    def test_iter_with_dataset(self):
-        p1 = Particle()
-        p2 = Particle()
-        p3 = Particle()
-        p4 = Particle()
+    def test_iter_datasets_dimention(self):
         ps1 = Particles('M1')
         ps2 = Particles('M2')
-        ps1.add_particles([p1, p2])
-        ps2.add_particles([p3, p4])
-        self.cuds.add(ps1)
-        self.cuds.add(ps2)
-
+        ps1.add_particles([Particle(), Particle()])
+        ps2.add_particles([Particle(), Particle()])
+        c = CUDS()
+        c.add(ps1)
+        c.add(ps2)
         cuds_list = []
-        for item in self.cuds.iter(Particles):
-            cuds_list.append(item)
+        for component in c.iter(Particles):
+            cuds_list.append(component)
 
         self.assertTrue(len(cuds_list), 2)
 
-        for cuds in cuds_list:
-            self.assertIsInstance(cuds, Particles)
-            self.assertIn(cuds, [ps1, ps2])
+    def test_iter_datasets_types(self):
+        dataset = Particles('M1')
+        dataset.add_particles([Particle(),
+                               Particle()])
+        c = CUDS()
+        c.add(dataset)
+
+        for ps in c.iter(Particles):
+            self.assertIsInstance(ps, Particles)
+            self.assertIn(ps, [dataset])
 
     def test_iter_with_component(self):
-        self.cuds.add(self.dummy_component1)
-        self.cuds.add(self.dummy_component2)
+        c = CUDS()
+
+        c.add(self.named_cuds_1)
+        c.add(self.named_cuds_2)
 
         component_list = []
-        for item in self.cuds.iter(type(self.dummy_component1)):
-            component_list.append(item)
+        for component in c.iter(type(self.named_cuds_1)):
+            component_list.append(component)
 
         self.assertTrue(len(component_list), 2)
         for cmp in component_list:
-            self.assertIn(cmp, [self.dummy_component1,
-                                self.dummy_component2])
+            self.assertIn(cmp, [self.named_cuds_1,
+                                self.named_cuds_2])

--- a/simphony/cuds/tests/test_cuds.py
+++ b/simphony/cuds/tests/test_cuds.py
@@ -61,9 +61,11 @@ class CUDSTestCase(unittest.TestCase):
 
     def test_add_nameless_cuds_component(self):
         c = CUDS()
+        c.add(self.nameless_cuds_1)
 
-        self.assertIsNone(c.add(self.nameless_cuds_1))
-        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+        self.assertEqual(c.get_by_uid(self.nameless_cuds_1.uid),
+                         self.nameless_cuds_1)
+        self.assertRaises(TypeError, c.get, self.nameless_cuds_1.name)
 
     def test_add_named_cuds_component(self):
         c = CUDS()
@@ -82,18 +84,20 @@ class CUDSTestCase(unittest.TestCase):
         c = CUDS()
         c.add(self.nameless_cuds_1)
         c.add(self.nameless_cuds_1)
+        component = c.get_by_uid(self.nameless_cuds_1.uid)
 
-        self.assertEqual(c.get_by_uid(self.nameless_cuds_1.uid),
+        self.assertEqual(component,
                          self.nameless_cuds_1)
-        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+        self.assertRaises(TypeError, c.get, component.name)
 
     def test_get_nameless_cuds_component(self):
         c = CUDS()
         c.add(self.nameless_cuds_1)
+        component = c.get_by_uid(self.nameless_cuds_1.uid)
 
-        self.assertEqual(c.get_by_uid(self.nameless_cuds_1.uid),
+        self.assertEqual(component,
                          self.nameless_cuds_1)
-        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+        self.assertRaises(TypeError, c.get, component.name)
 
     def test_get_named_cuds_component(self):
         c = CUDS()
@@ -149,8 +153,9 @@ class CUDSTestCase(unittest.TestCase):
 
         c.add(self.nameless_cuds_1)
         c.remove_by_uid(self.nameless_cuds_1.uid)
+        component = c.get_by_uid(self.nameless_cuds_1.uid)
 
-        self.assertIsNone(c.get(self.nameless_cuds_1.name))
+        self.assertIsNone(component)
 
     def test_remove_dataset(self):
         ps = Particles('my particles')

--- a/simphony/cuds/tests/test_cuds.py
+++ b/simphony/cuds/tests/test_cuds.py
@@ -1,8 +1,8 @@
 """Tests for CUDS data structure."""
 import unittest
-import uuid
 
 from simphony.api import CUDS
+from simphony.cuds.meta import api
 from simphony.cuds.particles import Particle, Particles
 
 
@@ -11,12 +11,11 @@ class CUDSTestCase(unittest.TestCase):
     def setUp(self):
         self.cuds = CUDS()
 
-        # TODO: use generated components
-        class DummyComponent(object):
+        class DummyComponent(api.CUDSComponent):
             def __init__(self):
-                self.uuid = uuid.uuid4()
+                super(DummyComponent, self).__init__()
                 self.name = 'dummyname'
-                self.data = {}
+
         self.dummpy_component1 = DummyComponent()
         self.dummpy_component2 = DummyComponent()
 
@@ -34,17 +33,14 @@ class CUDSTestCase(unittest.TestCase):
     def test_add_get_component(self):
         self.assertRaises(TypeError, self.cuds.add, object())
         self.cuds.add(self.dummpy_component1)
-        self.assertEqual(self.cuds.get(self.dummpy_component1.uuid),
+        self.assertEqual(self.cuds.get(self.dummpy_component1.uid),
                          self.dummpy_component1)
 
-    def test_add_component_with_no_uuid(self):
-        # Set the uuid to None
-        self.dummpy_component1.uuid = None
-
+    def test_component_uid_value(self):
         self.cuds.add(self.dummpy_component1)
 
-        self.assertIsNotNone(self.dummpy_component1.uuid)
-        self.assertEqual(self.cuds.get(self.dummpy_component1.uuid),
+        self.assertIsNotNone(self.dummpy_component1.uid)
+        self.assertEqual(self.cuds.get(self.dummpy_component1.uid),
                          self.dummpy_component1)
 
     def test_add_dataset(self):
@@ -58,8 +54,8 @@ class CUDSTestCase(unittest.TestCase):
 
     def test_remove_component(self):
         self.cuds.add(self.dummpy_component1)
-        self.cuds.remove(self.dummpy_component1.uuid)
-        self.assertIsNone(self.cuds.get(self.dummpy_component1.uuid))
+        self.cuds.remove(self.dummpy_component1.uid)
+        self.assertIsNone(self.cuds.get(self.dummpy_component1.uid))
 
     def test_remove_dataset(self):
         p1 = Particle()

--- a/simphony/cuds/tests/test_cuds.py
+++ b/simphony/cuds/tests/test_cuds.py
@@ -11,8 +11,8 @@ class CUDSTestCase(unittest.TestCase):
     def setUp(self):
         self.cuds = CUDS()
 
-        self.dummpy_component1 = api.Box(name='mybox')
-        self.dummpy_component2 = api.Box(name='mysecondbox')
+        self.dummy_component1 = api.Box(name='mybox')
+        self.dummy_component2 = api.Box(name='mysecondbox')
 
     def test_empty_cuds(self):
         self.assertEqual(len(self.cuds.data), 0)
@@ -28,19 +28,19 @@ class CUDSTestCase(unittest.TestCase):
     def test_add_get_component(self):
         # Add non-CUDS non-dataset object
         self.assertRaises(TypeError, self.cuds.add, object())
-        self.cuds.add(self.dummpy_component1)
-        self.assertEqual(self.cuds.get_by_uid(self.dummpy_component1.uid),
-                         self.dummpy_component1)
-        self.assertEqual(self.cuds.get(self.dummpy_component1.name),
-                         self.dummpy_component1)
+        self.cuds.add(self.dummy_component1)
+        self.assertEqual(self.cuds.get_by_uid(self.dummy_component1.uid),
+                         self.dummy_component1)
+        self.assertEqual(self.cuds.get(self.dummy_component1.name),
+                         self.dummy_component1)
 
     def test_add_duplicate(self):
-        self.cuds.add(self.dummpy_component1)
+        self.cuds.add(self.dummy_component1)
         # Name is the same
-        self.assertRaises(ValueError, self.cuds.add, self.dummpy_component1)
+        self.assertRaises(ValueError, self.cuds.add, self.dummy_component1)
         self.assertRaises(ValueError,
                           self.cuds.add,
-                          api.Material(name=self.dummpy_component1.name))
+                          api.Material(name=self.dummy_component1.name))
 
     def test_add_dataset(self):
         p1 = Particle()
@@ -53,13 +53,13 @@ class CUDSTestCase(unittest.TestCase):
         self.assertRaises(ValueError, self.cuds.add, ps)
 
     def test_remove_component(self):
-        self.cuds.add(self.dummpy_component1)
-        self.cuds.remove(self.dummpy_component1.name)
-        self.assertIsNone(self.cuds.get(self.dummpy_component1.name))
+        self.cuds.add(self.dummy_component1)
+        self.cuds.remove(self.dummy_component1.name)
+        self.assertIsNone(self.cuds.get(self.dummy_component1.name))
 
-        self.cuds.add(self.dummpy_component1)
-        self.cuds.remove_by_uid(self.dummpy_component1.uid)
-        self.assertIsNone(self.cuds.get_by_uid(self.dummpy_component1.uid))
+        self.cuds.add(self.dummy_component1)
+        self.cuds.remove_by_uid(self.dummy_component1.uid)
+        self.assertIsNone(self.cuds.get_by_uid(self.dummy_component1.uid))
 
     def test_remove_dataset(self):
         p1 = Particle()
@@ -83,12 +83,12 @@ class CUDSTestCase(unittest.TestCase):
         self.cuds.add(ps2)
         self.assertEqual(self.cuds.get_names(Particles), ['M1', 'M2'])
 
-        self.cuds.add(self.dummpy_component1)
-        self.cuds.add(self.dummpy_component2)
-        names = set(self.cuds.get_names(type(self.dummpy_component1)))
+        self.cuds.add(self.dummy_component1)
+        self.cuds.add(self.dummy_component2)
+        names = set(self.cuds.get_names(type(self.dummy_component1)))
         self.assertEqual(names,
-                         set([self.dummpy_component1.name,
-                              self.dummpy_component2.name]))
+                         set([self.dummy_component1.name,
+                              self.dummy_component2.name]))
 
     def test_iter_with_dataset(self):
         p1 = Particle()
@@ -113,14 +113,14 @@ class CUDSTestCase(unittest.TestCase):
             self.assertIn(cuds, [ps1, ps2])
 
     def test_iter_with_component(self):
-        self.cuds.add(self.dummpy_component1)
-        self.cuds.add(self.dummpy_component2)
+        self.cuds.add(self.dummy_component1)
+        self.cuds.add(self.dummy_component2)
 
         component_list = []
-        for item in self.cuds.iter(type(self.dummpy_component1)):
+        for item in self.cuds.iter(type(self.dummy_component1)):
             component_list.append(item)
 
         self.assertTrue(len(component_list), 2)
         for cmp in component_list:
-            self.assertIn(cmp, [self.dummpy_component1,
-                                self.dummpy_component2])
+            self.assertIn(cmp, [self.dummy_component1,
+                                self.dummy_component2])


### PR DESCRIPTION
This PR simplifies CUDS class. Adds `name` and `description` to `CUDS` and `Simulation` classes. Moreover, uses `name` as the main parameter to add/get/remove items inside CUDS.