### PR TITLE
PR: Feature: serialise CUDS model by Yaml script

### DIFF
--- a/simphony/io/serialisation.py
+++ b/simphony/io/serialisation.py
@@ -1,0 +1,291 @@
+import yaml
+import numpy
+
+from simphony.cuds.model import *
+from simphony.core.data_container import DataContainer
+from simphony.cuds.meta.cuds_component import CUDSComponent
+from simphony.core.keywords import KEYWORDS
+from simphony.cuds.meta import *
+from simphony.core.cuba import CUBA
+from collections import OrderedDict
+from importlib import import_module
+from simphony.cuds.meta.validation import to_camel_case
+
+_CUDSREFMAP = OrderedDict()
+
+
+def save_CUDS(handle, model):
+    """ Save CUDS model to a Yaml file
+
+    Parameters
+    ----------
+    handle: file handle
+        Yaml file where CUDS model is saved. File will be cleared.
+    model: CUDS model
+
+    """
+
+    handle.seek(0)
+    handle.truncate()
+
+    handle.write('- NAME:')
+    if model.name:
+        handle.write(' "'+model.name+'"')
+    else:
+        handle.write(' Null')
+    handle.write('\n\n')
+    handle.write('- DESCRIPTION:')
+    if model.description:
+        handle.write(' "'+model.description+'"')
+    else:
+        handle.write(' Null')
+    handle.write('\n')
+    #handle.write('# COMPONENTS')
+
+    # Construct a map of referenced objects
+    global _CUDSREFMAP
+    _CUDSREFMAP.clear()
+    for comp in model.iter(CUDSComponent):
+        # Add component to dictionary if it's not there already
+        if comp.uid not in _CUDSREFMAP.keys():
+            _CUDSREFMAP[comp.uid] = []
+        # Check if the component has CUDSComponents in data
+        for data in comp._data.values():
+            # either directly, or
+            if isinstance(data, CUDSComponent):
+                if data.uid not in _CUDSREFMAP.keys():
+                    _CUDSREFMAP[data.uid] = []
+                _CUDSREFMAP[data.uid] += [comp.uid]
+            # as an element of a list
+            if type(data) == list:
+                for elem in data:
+                    if isinstance(elem, CUDSComponent):
+                        if elem.uid not in _CUDSREFMAP.keys():
+                            _CUDSREFMAP[elem.uid] = []
+                        _CUDSREFMAP[elem.uid] += [comp.uid]
+
+    # Save CUDSComponents
+    for comp in model.iter(CUDSComponent):
+        if _CUDSREFMAP[comp.uid] is not 'saved':
+            stream = ''
+            stream = _CUDSComponent_to_yaml(comp, stream)
+            handle.write(stream)
+            _CUDSREFMAP[comp.uid] = 'saved'
+
+
+def load_CUDS(handle):
+    """ Load CUDS model from a Yaml file
+
+    Parameters
+    ----------
+    handle: file handle
+        yaml file containing CUDSComponents
+
+    Raises
+    ------
+    FileError
+        if yaml file contains errors
+
+    Returns
+    -------
+    model: CUDS
+        computational model
+
+    """
+
+    comp_dict = {}
+    name = None
+    desc = None
+    for data in yaml.safe_load_all(handle):
+        # Go through the dictionaries constructed from the Yaml script
+        for dict_cuds in data:
+            cubatype = dict_cuds.keys()[0]
+            if cubatype == 'NAME':
+                name = dict_cuds['NAME']
+            elif cubatype == 'DESCRIPTION':
+                desc = dict_cuds['DESCRIPTION']
+            else:
+                _dict_to_CUDSComponent(cubatype, dict_cuds[cubatype], comp_dict)
+
+    model = CUDS(name = name, description = desc)
+    for compid in comp_dict.keys():
+        model.add(comp_dict[compid])
+
+    return model
+
+
+def _CUDSComponent_to_yaml(comp, stream):
+    """ Convert CUDSComponent containing data to Yaml script
+
+    Parameters
+    ----------
+    comp: CUDSComponent
+        CUDSComponent that will be converted to Yaml
+    stream: str
+        A string to which new Yaml script is added
+
+    Returns
+    -------
+    str
+        A string containing Yaml script of the added CUDSComponent and it's
+        sub-components
+
+    """
+
+    # Use global (at module level) dictionary for bookkeeping of the
+    # references and of the saved components
+    global _CUDSREFMAP
+    yaml_comp = '\n'
+    yaml_comp += '- ' + str(comp.cuba_key).replace('CUBA.', '') + ':'
+
+    # Check if 'comp' is referenced by some other CUDSComponent in the model
+    # and create an alias if needed
+    if _CUDSREFMAP[comp.uid]:
+        refnum = _CUDSREFMAP.keys().index(comp.uid) + 1
+        yaml_comp += ' &' + str(refnum)
+    yaml_comp += '\n'
+
+    # Go through the keys in the component
+    cdata = comp._data
+    for key in cdata.keys():
+        # Check if the data is a list or numpy types or CUDSComponents
+        if type(cdata[key]) == list:
+            # List of simple types?
+            if KEYWORDS[key._name_].dtype in [numpy.float64,
+                    numpy.int32, bool]:
+                items = []
+                for item in cdata[key]:
+                    items.append(item.tolist())
+                value = str(items)
+
+            # List of CUDSComponents
+            else:
+                value = '['
+                for item in cdata[key]:
+                    if isinstance(item, CUDSComponent):
+                        if len(value) > 1:
+                            value += ', '
+                        # CUDSComponent will be referenced by a small int
+                        # number in the Yaml script
+                        refnum = _CUDSREFMAP.keys().index(item.uid) + 1
+                        value += '*' + str(refnum)
+
+                        # Check from _CUDSREFMAP dictionary if the object
+                        # referenced is not already saved
+                        if _CUDSREFMAP[item.uid] is not 'saved' or []:
+                            _CUDSREFMAP[item.uid] = 'saved'
+                            # Generate Yaml script for this component
+                            stream = _CUDSComponent_to_yaml(item, stream)
+                value += ']'
+
+        # Only one CUDSComponent?
+        elif isinstance(cdata[key], CUDSComponent):
+            refnum = _CUDSREFMAP.keys().index(cdata[key].uid) + 1
+            value = '*' + str(refnum)
+
+            # Use _CUDSREFMAP dictionary to mark already saved
+            # referenced objects
+            if _CUDSREFMAP[cdata[key].uid] is not 'saved' or []:
+                _CUDSREFMAP[cdata[key].uid] = 'saved'
+                # Generate Yaml script for this component
+                stream = _CUDSComponent_to_yaml(cdata[key], stream)
+
+        # Any of the simple data types?
+        elif type(cdata[key]) == str:
+            value = '"' + str(cdata[key]) + '"'
+        elif type(cdata[key]) == numpy.ndarray:
+            value = str(cdata[key].tolist())
+        elif cdata[key] is None:
+            value = None
+        else:
+            value = str(cdata[key])
+
+        # Write only key-value pairs where value is not None
+        if value:
+            yaml_comp += '    ' + str(key).replace('CUBA.', '') + \
+                ': ' + value + '\n'
+    stream = stream + yaml_comp
+    return stream
+
+
+def _dict_to_CUDSComponent(cubatype, comp, comp_dict = {}):
+    """ Generate a CUDSComponent on the basis of a dictionary
+    provided by PyYaml library.
+
+    Parameters
+    ----------
+    cubatype: str
+        CUBA key (name) of the CUDSComponent in the format use in Yaml file
+    comp: dict
+        Dictionary object containing the parameters of the component.
+    comp_dict: dict
+        Dictionary where constructed CUDSComponents are added
+        with a Python id as reference: key-value pairs are of the format
+            id(CUDSComponent): CUDSComponent
+
+    """
+
+    # Check that comp does not refer to one of the components that
+    # have been already constructed
+    if id(comp) in comp_dict.keys():
+        return
+
+    if cubatype in KEYWORDS.keys():
+        # Find corresponding module and instantiate the class
+        mod = import_module('simphony.cuds.meta.%s' % cubatype.lower())
+        comp_class = getattr(mod, to_camel_case(cubatype))
+
+        # Must use (at least) two None parameters here, because currently
+        # there is no (easy) way to read required parameters for
+        # a class that is dynamically instantiated. A solution would be
+        # to define default values, e.g. 'None', for all parameters that
+        # do not have it defined yet.
+        comp_inst = comp_class(None, None)
+
+        # Go through the keys and values in comp dictionary and
+        # add supported ones to data_dict
+        data_dict = {}
+        supp_params = [str(e).replace('CUBA.','')
+            for e in comp_inst.supported_parameters()]
+        for key in comp.keys():
+            # Check if it is safe to eval the key
+            if key in supp_params:
+                cubakey = eval('CUBA.' + key)
+
+                # Check if value contains other CUDSComponents or data
+                value = comp[key]
+                if type(value) is list:
+                    tmp = []
+                    for subcomp in value:
+                        if type(subcomp) is dict:
+                            # Construct the subcomponent before it can be
+                            # added to the host component
+                            _dict_to_CUDSComponent(key, subcomp, comp_dict)
+                            tmp.append(comp_dict[id(subcomp)])
+                        else:
+                            #validation.validate_cuba_keyword(subcomp, key)
+                            tmp.append(subcomp)
+                    data_dict[cubakey] = tmp
+                elif type(value) is dict:
+                    _dict_to_CUDSComponent(key, value, comp_dict)
+                else:
+                    #validation.validate_cuba_keyword(value, key)
+                    data_dict[cubakey] = value
+            else:
+                message = 'Unknown CUDSComponent "{}" as a subcomponent'
+                raise ValueError(message.format(key))
+
+        # CUDSComponent data setter overwrites
+        # existing data attribute with the contents of data_dict,
+        # and removes CUBA.NAME key if it doesn't exist in data_dict
+        if CUBA.NAME not in data_dict.keys():
+            data_dict[CUBA.NAME] = None
+        # Add data to the constructed CUDSComponent
+        comp_inst.data = data_dict
+    else:
+        message = 'Unknown CUDSComponent "{}"'
+        raise ValueError(message.format(cubatype))
+
+    # Store component under the key representing it's memory location
+    # so that correct object references from the yaml file are preserved
+    comp_dict[id(comp)] = comp_inst

--- a/simphony/io/serialisation.py
+++ b/simphony/io/serialisation.py
@@ -40,7 +40,6 @@ def save_CUDS(handle, model):
     else:
         handle.write(' Null')
     handle.write('\n')
-    #handle.write('# COMPONENTS')
 
     # Construct a map of referenced objects
     global _CUDSREFMAP
@@ -105,7 +104,8 @@ def load_CUDS(handle):
             elif cubatype == 'DESCRIPTION':
                 desc = dict_cuds['DESCRIPTION']
             else:
-                _dict_to_CUDSComponent(cubatype, dict_cuds[cubatype], comp_dict)
+                _dict_to_CUDSComponent(cubatype, dict_cuds[cubatype],
+                                       comp_dict)
 
     model = CUDS(name = name, description = desc)
     for compid in comp_dict.keys():
@@ -263,13 +263,13 @@ def _dict_to_CUDSComponent(cubatype, comp, comp_dict = {}):
                             _dict_to_CUDSComponent(key, subcomp, comp_dict)
                             tmp.append(comp_dict[id(subcomp)])
                         else:
-                            #validation.validate_cuba_keyword(subcomp, key)
+                            # validation.validate_cuba_keyword(subcomp, key)
                             tmp.append(subcomp)
                     data_dict[cubakey] = tmp
                 elif type(value) is dict:
                     _dict_to_CUDSComponent(key, value, comp_dict)
                 else:
-                    #validation.validate_cuba_keyword(value, key)
+                    # validation.validate_cuba_keyword(value, key)
                     data_dict[cubakey] = value
             else:
                 message = 'Unknown CUDSComponent "{}" as a subcomponent'

--- a/simphony/io/serialisation.py
+++ b/simphony/io/serialisation.py
@@ -1,11 +1,10 @@
 import yaml
 import numpy
 
-from simphony.cuds.model import *
-from simphony.core.data_container import DataContainer
+from simphony.cuds.model import CUDS
 from simphony.cuds.meta.cuds_component import CUDSComponent
 from simphony.core.keywords import KEYWORDS
-from simphony.cuds.meta import *
+# from simphony.cuds.meta import *
 from simphony.core.cuba import CUBA
 from collections import OrderedDict
 from importlib import import_module
@@ -107,7 +106,7 @@ def load_CUDS(handle):
                 _dict_to_CUDSComponent(cubatype, dict_cuds[cubatype],
                                        comp_dict)
 
-    model = CUDS(name = name, description = desc)
+    model = CUDS(name=name, description=desc)
     for compid in comp_dict.keys():
         model.add(comp_dict[compid])
 
@@ -152,7 +151,7 @@ def _CUDSComponent_to_yaml(comp, stream):
         if type(cdata[key]) == list:
             # List of simple types?
             if KEYWORDS[key._name_].dtype in [numpy.float64,
-                    numpy.int32, bool]:
+                                              numpy.int32, bool]:
                 items = []
                 for item in cdata[key]:
                     items.append(item.tolist())
@@ -208,7 +207,7 @@ def _CUDSComponent_to_yaml(comp, stream):
     return stream
 
 
-def _dict_to_CUDSComponent(cubatype, comp, comp_dict = {}):
+def _dict_to_CUDSComponent(cubatype, comp, comp_dict={}):
     """ Generate a CUDSComponent on the basis of a dictionary
     provided by PyYaml library.
 
@@ -245,8 +244,8 @@ def _dict_to_CUDSComponent(cubatype, comp, comp_dict = {}):
         # Go through the keys and values in comp dictionary and
         # add supported ones to data_dict
         data_dict = {}
-        supp_params = [str(e).replace('CUBA.','')
-            for e in comp_inst.supported_parameters()]
+        supp_params = [str(e).replace('CUBA.', '')
+                       for e in comp_inst.supported_parameters()]
         for key in comp.keys():
             # Check if it is safe to eval the key
             if key in supp_params:

--- a/simphony/io/serialisation.py
+++ b/simphony/io/serialisation.py
@@ -263,7 +263,7 @@ def _dict_to_CUDSComponent(cubatype, comp, comp_dict={}):
                     if key.lower() in init_params:
                         init_kwargs[key.lower()] = tmp
                     else:
-                        cubaname = eval('CUBA.' + key)
+                        cubaname = CUBA[key]
                         system_managed_keys[cubaname] = tmp
                 elif type(value) is dict:
                     _dict_to_CUDSComponent(key, value, comp_dict)
@@ -275,15 +275,13 @@ def _dict_to_CUDSComponent(cubatype, comp, comp_dict={}):
                 if key.lower() in init_params:
                     init_kwargs[key.lower()] = tmp
                 else:
-                    cubaname = eval('CUBA.' + key)
+                    cubaname = CUBA[key]
                     system_managed_keys[cubaname] = tmp
 
             else:
                 message = 'Unknown CUDSComponent "{}" as a subcomponent'
                 raise ValueError(message.format(key))
 
-        #if 'name' not in init_kwargs.keys():
-        #    init_kwargs['name'] = None
         # Instantiate component with its subcomponents
         comp_inst = comp_class(**init_kwargs)
         # Add system managed components by updating the DataContainer

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -1,0 +1,153 @@
+"""
+    Testing module for CUDS serialization functions.
+"""
+import unittest
+import os
+from contextlib import closing
+import tempfile
+from numpy.testing import assert_array_equal
+
+from simphony.cuds.model import *
+from simphony.core.data_container import DataContainer
+
+from simphony.cuds.meta.cuds_component import CUDSComponent
+
+import numpy
+import string
+import random
+from simphony.core.keywords import KEYWORDS
+from simphony.cuds.meta import *
+from simphony.core.cuba import CUBA
+from uuid import UUID
+from simphony.io.serialization import *
+from collections import OrderedDict
+from importlib import import_module
+from simphony.cuds.meta.validation import to_camel_case
+
+
+
+class TestSerialization(unittest.TestCase):
+    """Tests for CUDS Yaml serialization functions."""
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_save_CUDS_name(self):
+        name = 'somename'
+        filename = os.path.join(self.temp_dir, 'test_named.yml')
+        C = CUDS(name = name)
+        with closing(open(filename,'w')) as handle:
+            save_CUDS(handle, C)
+
+        CC = None
+        with closing(open(filename,'r')) as handle:
+            CC = load_CUDS(handle)
+
+        self.assertEqual(CC.name, name)
+
+    def test_save_CUDS_description(self):
+        description = 'some very long description'
+        filename = os.path.join(self.temp_dir, 'test_description.yml')
+        C = CUDS(description = description)
+        with closing(open(filename,'w')) as handle:
+            save_CUDS(handle, C)
+
+        with closing(open(filename,'r')) as handle:
+            CC = load_CUDS(handle)
+
+        self.assertEqual(CC.description, description)
+
+    def test_save_CUDS_empty(self):
+        filename = os.path.join(self.temp_dir, 'test_empty.yml')
+        C = CUDS(name = 'empty', description = 'just an empty model')
+        with closing(open(filename,'w')) as handle:
+            save_CUDS(handle, C)
+
+        CC = None
+        with closing(open(filename,'r')) as handle:
+            CC = load_CUDS(handle)
+
+        self.assertEqual(CC.name, C.name)
+        self.assertEqual(CC.description, C.description)
+
+        for item in CC.iter():
+            self.assertEqual(item, None)
+
+
+    def test_save_CUDS_full(self):
+        filename = os.path.join(self.temp_dir, 'test_full.yml')
+        C = CUDS(name = 'full', description = 'fully randomized model')
+
+        for key in KEYWORDS.keys():
+            if key not in ['VERSION']:
+                comp = self._create_random_CUDSComponent(key)
+                if comp:
+                    C.add(comp)
+
+        with closing(open(filename,'w')) as handle:
+            save_CUDS(handle, C)
+
+        CC = None
+        with closing(open(filename,'r')) as handle:
+            CC = load_CUDS(handle)
+
+        self.assertEqual(CC.name, C.name)
+        self.assertEqual(CC.description, C.description)
+
+        for CCitem in CC.iter():
+            Citem = C.get(CCitem.name)
+            self.assertEqual(Citem.name, CCitem.name)
+
+    def _ran(self, dtype, shape):
+        if dtype == numpy.int32:
+            if shape == []:
+                shape = [1]
+            return numpy.random.randint(-9999999,9999999,size = shape)
+        elif dtype == numpy.float64:
+            if shape == [] or shape == None:
+                return numpy.random.rand(3)
+            elif len(shape) == 2:
+                return numpy.random.rand(shape[0],shape[1])
+            elif len(shape) == 1:
+                if shape[0] == 1:
+                    return numpy.random.rand(1)[0]
+                else:
+                    return numpy.random.rand(shape[0])
+        elif dtype == str:
+            return ''.join(random.choice(string.ascii_uppercase +
+                string.digits) for _ in range(shape[0]))
+        elif dtype == bool:
+            return random.choice([True, False])
+
+    def _create_random_CUDSComponent(self, key):
+        api = import_module('simphony.cuds.meta.api')
+        if to_camel_case(key) in dir(api):
+            mod = import_module('simphony.cuds.meta.%s' % key.lower())
+            comp_class = getattr(mod, to_camel_case(key))
+
+            if issubclass(comp_class, CUDSComponent):
+                comp_inst = comp_class(None, None)
+                data_dict = {}
+                for prm in comp_inst.supported_parameters():
+                    if prm is not CUBA.UUID:
+                        name = str(prm).replace('CUBA.','')
+                        if to_camel_case(name) in dir(api):
+                            # Create one or two subcomponents if supported
+                            if numpy.random.randint(2):
+                                subcomp1 =
+                                    self._create_random_CUDSComponent(name)
+                                data_dict[prm] = subcomp1
+                            else:
+                                subcomp1 = random_component(name)
+                                subcomp2 = random_component(name)
+                                data_dict[prm] = [subcomp1, subcomp2]
+                        else:
+                            dtype = KEYWORDS[name].dtype
+                            shape = KEYWORDS[name].shape
+                            val = self._ran(dtype, shape)
+                            data_dict[prm] = val
+                comp_inst.data = data_dict
+                return comp_inst
+        return None

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -99,11 +99,12 @@ class TestSerialisation(unittest.TestCase):
                     CCi = CCitem.data[key]
                     _compare_components(Ci, CCi, testcase=self)
 
+
 def _compare_components(comp1, comp2, testcase):
     self = testcase
     if type(comp1) == list:
         for i in xrange(len(comp1)):
-            if isinstance(comp1[i], CUDSComponent)
+            if isinstance(comp1[i], CUDSComponent):
                 _compare_components(comp1[i], comp2[i], self)
             else:
                 self.assertEqual(comp1[i], comp2[i])
@@ -111,7 +112,7 @@ def _compare_components(comp1, comp2, testcase):
         for key, value in comp1.data:
             if type(value) == list:
                 for i in xrange(len(value)):
-                    if isinstance(value[i], CUDSComponent)
+                    if isinstance(value[i], CUDSComponent):
                         _compare_components(value[i], comp2.data[key][i],
                                             self)
                     else:

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -7,23 +7,18 @@ from contextlib import closing
 import tempfile
 from numpy.testing import assert_array_equal
 
-from simphony.cuds.model import *
-from simphony.core.data_container import DataContainer
-
 from simphony.cuds.meta.cuds_component import CUDSComponent
 
 import numpy
 import string
 import random
 from simphony.core.keywords import KEYWORDS
-from simphony.cuds.meta import *
 from simphony.core.cuba import CUBA
 from uuid import UUID
 from simphony.io.serialization import *
 from collections import OrderedDict
 from importlib import import_module
 from simphony.cuds.meta.validation import to_camel_case
-
 
 
 class TestSerialization(unittest.TestCase):
@@ -82,7 +77,7 @@ class TestSerialization(unittest.TestCase):
 
         for key in KEYWORDS.keys():
             if key not in ['VERSION']:
-                comp = self._create_random_CUDSComponent(key)
+                comp = self._create_random_comp(key)
                 if comp:
                     C.add(comp)
 
@@ -106,7 +101,7 @@ class TestSerialization(unittest.TestCase):
                 shape = [1]
             return numpy.random.randint(-9999999, 9999999, size=shape)
         elif dtype == numpy.float64:
-            if shape == [] or shape == None:
+            if shape == [] or shape is None:
                 return numpy.random.rand(3)
             elif len(shape) == 2:
                 return numpy.random.rand(shape[0], shape[1])
@@ -121,7 +116,7 @@ class TestSerialization(unittest.TestCase):
         elif dtype == bool:
             return random.choice([True, False])
 
-    def _create_random_CUDSComponent(self, key):
+    def _create_random_comp(self, key):
         api = import_module('simphony.cuds.meta.api')
         if to_camel_case(key) in dir(api):
             mod = import_module('simphony.cuds.meta.%s' % key.lower())
@@ -136,8 +131,7 @@ class TestSerialization(unittest.TestCase):
                         if to_camel_case(name) in dir(api):
                             # Create one or two subcomponents if supported
                             if numpy.random.randint(2):
-                                subcomp1
-                                    = self._create_random_CUDSComponent(name)
+                                subcomp1 = self._create_random_comp(name)
                                 data_dict[prm] = subcomp1
                             else:
                                 subcomp1 = random_component(name)

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -109,7 +109,7 @@ def _compare_components(comp1, comp2, testcase):
             else:
                 self.assertEqual(comp1[i], comp2[i])
     elif isinstance(comp1, CUDSComponent):
-        for key, value in comp1.data:
+        for key, value in comp1.data.iteritems():
             if type(value) == list:
                 for i in xrange(len(value)):
                     if isinstance(value[i], CUDSComponent):

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -3,21 +3,19 @@
 """
 import unittest
 import os
+import shutil
 from contextlib import closing
 import tempfile
-from numpy.testing import assert_array_equal
-
-from simphony.cuds.meta.cuds_component import CUDSComponent
-
 import numpy
 import string
 import random
+from importlib import import_module
+
+from simphony.cuds.meta.cuds_component import CUDSComponent
+from simphony.cuds.model import CUDS
 from simphony.core.keywords import KEYWORDS
 from simphony.core.cuba import CUBA
-from uuid import UUID
-from simphony.io.serialization import *
-from collections import OrderedDict
-from importlib import import_module
+from simphony.io.serialisation import save_CUDS, load_CUDS
 from simphony.cuds.meta.validation import to_camel_case
 
 
@@ -33,11 +31,11 @@ class TestSerialization(unittest.TestCase):
         name = 'somename'
         filename = os.path.join(self.temp_dir, 'test_named.yml')
         C = CUDS(name=name)
-        with closing(open(filename,'w')) as handle:
+        with closing(open(filename, 'w')) as handle:
             save_CUDS(handle, C)
 
         CC = None
-        with closing(open(filename,'r')) as handle:
+        with closing(open(filename, 'r')) as handle:
             CC = load_CUDS(handle)
 
         self.assertEqual(CC.name, name)
@@ -46,10 +44,10 @@ class TestSerialization(unittest.TestCase):
         description = 'some very long description'
         filename = os.path.join(self.temp_dir, 'test_description.yml')
         C = CUDS(description=description)
-        with closing(open(filename,'w')) as handle:
+        with closing(open(filename, 'w')) as handle:
             save_CUDS(handle, C)
 
-        with closing(open(filename,'r')) as handle:
+        with closing(open(filename, 'r')) as handle:
             CC = load_CUDS(handle)
 
         self.assertEqual(CC.description, description)
@@ -57,11 +55,11 @@ class TestSerialization(unittest.TestCase):
     def test_save_CUDS_empty(self):
         filename = os.path.join(self.temp_dir, 'test_empty.yml')
         C = CUDS(name='empty', description='just an empty model')
-        with closing(open(filename,'w')) as handle:
+        with closing(open(filename, 'w')) as handle:
             save_CUDS(handle, C)
 
         CC = None
-        with closing(open(filename,'r')) as handle:
+        with closing(open(filename, 'r')) as handle:
             CC = load_CUDS(handle)
 
         self.assertEqual(CC.name, C.name)
@@ -69,7 +67,6 @@ class TestSerialization(unittest.TestCase):
 
         for item in CC.iter():
             self.assertEqual(item, None)
-
 
     def test_save_CUDS_full(self):
         filename = os.path.join(self.temp_dir, 'test_full.yml')
@@ -111,8 +108,9 @@ class TestSerialization(unittest.TestCase):
                 else:
                     return numpy.random.rand(shape[0])
         elif dtype == str:
-            return ''.join(random.choice(string.ascii_uppercase +
-                    string.digits) for _ in range(shape[0]))
+            randstr = ''.join(random.choice(string.ascii_uppercase)
+                              for _ in range(shape[0]))
+            return randstr
         elif dtype == bool:
             return random.choice([True, False])
 
@@ -134,8 +132,8 @@ class TestSerialization(unittest.TestCase):
                                 subcomp1 = self._create_random_comp(name)
                                 data_dict[prm] = subcomp1
                             else:
-                                subcomp1 = random_component(name)
-                                subcomp2 = random_component(name)
+                                subcomp1 = self._create_random_comp(name)
+                                subcomp2 = self._create_random_comp(name)
                                 data_dict[prm] = [subcomp1, subcomp2]
                         else:
                             dtype = KEYWORDS[name].dtype

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -65,7 +65,7 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(CC.name, C.name)
         self.assertEqual(CC.description, C.description)
 
-        for item in CC.iter():
+        for item in CC.iter(CUDSComponent):
             self.assertEqual(item, None)
 
     def test_save_CUDS_full(self):
@@ -88,7 +88,7 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(CC.name, C.name)
         self.assertEqual(CC.description, C.description)
 
-        for CCitem in CC.iter():
+        for CCitem in CC.iter(CUDSComponent):
             Citem = C.get(CCitem.name)
             self.assertEqual(Citem.name, CCitem.name)
 

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -87,7 +87,7 @@ class TestSerialisation(unittest.TestCase):
         # that they are present in the loaded model
         for Citem in C.iter(CUDSComponent):
             # Check items that have name parameter defined
-            if hasattr(Citem, 'name'):
+            if Citem.name is not None:
                 CCitem = CC.get(Citem.name)
                 self.assertEqual(CCitem.name, Citem.name)
                 for key in Citem.data:

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -94,6 +94,28 @@ class TestSerialisation(unittest.TestCase):
             # Check items that have name parameter defined
             if Citem.name is not None:
                 CCitem = CC.get(Citem.name)
-                self.assertEqual(CCitem.name, Citem.name)
-                for key in Citem.data:
-                    self.assertEqual(Citem.data[key], CCitem.data[key])
+                for key in Citem.data.keys():
+                    Ci = Citem.data[key]
+                    CCi = CCitem.data[key]
+                    _compare_components(Ci, CCi, testcase=self)
+
+def _compare_components(comp1, comp2, testcase):
+    self = testcase
+    if type(comp1) == list:
+        for i in xrange(len(comp1)):
+            if isinstance(comp1[i], CUDSComponent)
+                _compare_components(comp1[i], comp2[i], self)
+            else:
+                self.assertEqual(comp1[i], comp2[i])
+    elif isinstance(comp1, CUDSComponent):
+        for key, value in comp1.data:
+            if type(value) == list:
+                for i in xrange(len(value)):
+                    if isinstance(value[i], CUDSComponent)
+                        _compare_components(value[i], comp2.data[key][i],
+                                            self)
+                    else:
+                        self.assertEqual(value[i], comp2.data[key][i])
+            self.assertEqual(value, comp2.data[key])
+    else:
+        self.assertEqual(comp1, comp2)

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -11,9 +11,8 @@ from simphony.cuds.meta.cuds_component import CUDSComponent
 from simphony.cuds.meta.material import Material
 from simphony.cuds.meta.material_relation import MaterialRelation
 from simphony.cuds.model import CUDS
-from simphony.core.keywords import KEYWORDS
-from simphony.core.cuba import CUBA
 from simphony.io.serialisation import save_CUDS, load_CUDS
+
 
 class TestSerialisation(unittest.TestCase):
     """Tests for CUDS Yaml serialisation functions."""

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -37,7 +37,7 @@ class TestSerialization(unittest.TestCase):
     def test_save_CUDS_name(self):
         name = 'somename'
         filename = os.path.join(self.temp_dir, 'test_named.yml')
-        C = CUDS(name = name)
+        C = CUDS(name=name)
         with closing(open(filename,'w')) as handle:
             save_CUDS(handle, C)
 
@@ -50,7 +50,7 @@ class TestSerialization(unittest.TestCase):
     def test_save_CUDS_description(self):
         description = 'some very long description'
         filename = os.path.join(self.temp_dir, 'test_description.yml')
-        C = CUDS(description = description)
+        C = CUDS(description=description)
         with closing(open(filename,'w')) as handle:
             save_CUDS(handle, C)
 
@@ -61,7 +61,7 @@ class TestSerialization(unittest.TestCase):
 
     def test_save_CUDS_empty(self):
         filename = os.path.join(self.temp_dir, 'test_empty.yml')
-        C = CUDS(name = 'empty', description = 'just an empty model')
+        C = CUDS(name='empty', description='just an empty model')
         with closing(open(filename,'w')) as handle:
             save_CUDS(handle, C)
 
@@ -78,7 +78,7 @@ class TestSerialization(unittest.TestCase):
 
     def test_save_CUDS_full(self):
         filename = os.path.join(self.temp_dir, 'test_full.yml')
-        C = CUDS(name = 'full', description = 'fully randomized model')
+        C = CUDS(name='full', description='fully randomized model')
 
         for key in KEYWORDS.keys():
             if key not in ['VERSION']:
@@ -86,11 +86,11 @@ class TestSerialization(unittest.TestCase):
                 if comp:
                     C.add(comp)
 
-        with closing(open(filename,'w')) as handle:
+        with closing(open(filename, 'w')) as handle:
             save_CUDS(handle, C)
 
         CC = None
-        with closing(open(filename,'r')) as handle:
+        with closing(open(filename, 'r')) as handle:
             CC = load_CUDS(handle)
 
         self.assertEqual(CC.name, C.name)
@@ -104,12 +104,12 @@ class TestSerialization(unittest.TestCase):
         if dtype == numpy.int32:
             if shape == []:
                 shape = [1]
-            return numpy.random.randint(-9999999,9999999,size = shape)
+            return numpy.random.randint(-9999999, 9999999, size=shape)
         elif dtype == numpy.float64:
             if shape == [] or shape == None:
                 return numpy.random.rand(3)
             elif len(shape) == 2:
-                return numpy.random.rand(shape[0],shape[1])
+                return numpy.random.rand(shape[0], shape[1])
             elif len(shape) == 1:
                 if shape[0] == 1:
                     return numpy.random.rand(1)[0]
@@ -117,7 +117,7 @@ class TestSerialization(unittest.TestCase):
                     return numpy.random.rand(shape[0])
         elif dtype == str:
             return ''.join(random.choice(string.ascii_uppercase +
-                string.digits) for _ in range(shape[0]))
+                    string.digits) for _ in range(shape[0]))
         elif dtype == bool:
             return random.choice([True, False])
 
@@ -132,12 +132,12 @@ class TestSerialization(unittest.TestCase):
                 data_dict = {}
                 for prm in comp_inst.supported_parameters():
                     if prm is not CUBA.UUID:
-                        name = str(prm).replace('CUBA.','')
+                        name = str(prm).replace('CUBA.', '')
                         if to_camel_case(name) in dir(api):
                             # Create one or two subcomponents if supported
                             if numpy.random.randint(2):
-                                subcomp1 =
-                                    self._create_random_CUDSComponent(name)
+                                subcomp1
+                                    = self._create_random_CUDSComponent(name)
                                 data_dict[prm] = subcomp1
                             else:
                                 subcomp1 = random_component(name)

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -6,18 +6,14 @@ import os
 import shutil
 from contextlib import closing
 import tempfile
-import numpy
-import string
-import random
-from importlib import import_module
 
 from simphony.cuds.meta.cuds_component import CUDSComponent
+from simphony.cuds.meta.material import Material
+from simphony.cuds.meta.material_relation import MaterialRelation
 from simphony.cuds.model import CUDS
 from simphony.core.keywords import KEYWORDS
 from simphony.core.cuba import CUBA
 from simphony.io.serialisation import save_CUDS, load_CUDS
-from simphony.cuds.meta.validation import to_camel_case
-from simphony.cuds.meta import api
 
 class TestSerialisation(unittest.TestCase):
     """Tests for CUDS Yaml serialisation functions."""
@@ -69,14 +65,14 @@ class TestSerialisation(unittest.TestCase):
         C = CUDS(name='full',
                  description='model with crossreferenced components')
 
-        M1 = Material(name = 'steel',
-                      description = 'FCC steel sphere structure')
-        M2 = Material(name = 'epoxy', description = '')
-        M3 = Material(name = 'iron', description = 'sheet metal container')
-        MR1 = MaterialRelation(name = 'steel spheres in epoxy',
-                              material = [M1,M2])
-        MR2 = MaterialRelation(name = 'epoxy in sheet metal container',
-                               material = [M2,M3])
+        M1 = Material(name='steel',
+                      description='FCC steel sphere structure')
+        M2 = Material(name='epoxy', description='')
+        M3 = Material(name='iron', description='sheet metal container')
+        MR1 = MaterialRelation(name='steel spheres in epoxy',
+                               material=[M1, M2])
+        MR2 = MaterialRelation(name='epoxy in sheet metal container',
+                               material=[M2, M3])
         # M1 is not added
         C.add(M2)
         C.add(M3)

--- a/simphony/io/tests/test_serialisation.py
+++ b/simphony/io/tests/test_serialisation.py
@@ -87,10 +87,10 @@ class TestSerialisation(unittest.TestCase):
         # that they are present in the loaded model
         for Citem in C.iter(CUDSComponent):
             # Check items that have name parameter defined
-            if hasattr(CCitem, 'name'):
-                Citem = C.get(CCitem.name)
-                self.assertEqual(Citem.name, CCitem.name)
-                for key in CCitem.data:
+            if hasattr(Citem, 'name'):
+                CCitem = CC.get(Citem.name)
+                self.assertEqual(CCitem.name, Citem.name)
+                for key in Citem.data:
                     self.assertEqual(Citem.data[key], CCitem.data[key])
 
     def _ran(self, dtype, shape):


### PR DESCRIPTION
This PR adds a feature to save and load CUDS models from Yaml files. This is a work-in-progress version, but the users are encouraged to try it and test how it fits to different use-cases.

functions:
- save_CUDS(handle, model)
- load_CUDS(handle) (returns model)
