### PR TITLE
Fixed typo in test

### DIFF
--- a/simphony/testing/tests/test_utils.py
+++ b/simphony/testing/tests/test_utils.py
@@ -112,7 +112,7 @@ class TestCompareMeshDatasets(unittest.TestCase):
         mesh = Mesh(name="test")
         reference = Mesh(name="test")
 
-        point_list = create_particles_with_id()
+        point_list = create_points_with_id()
         edge_list = create_edges()
         face_list = create_faces()
         cell_list = create_cells()
@@ -140,7 +140,7 @@ class TestCompareMeshDatasets(unittest.TestCase):
         mesh = Mesh(name="test")
         reference = Mesh(name="test_ref")
 
-        point_list = create_particles_with_id()
+        point_list = create_points_with_id()
         edge_list = create_edges()
         face_list = create_faces()
         cell_list = create_cells()


### PR DESCRIPTION
Creating particles, while it should really create points. It is interesting to note that the tests don't pick the error.
