### PR TITLE
Problem: travis config uses system-wide python packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
 - '2.7'
 virtualenv:
-  system_site_packages: true
+  system_site_packages: false
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 - popd
 script:
 - flake8 .
-- coverage run -m unittest discover -p test*
+- py.test -v
 - sphinx-build -W doc/source doc/build/sphinx
 after_success:
 - pip install codecov


### PR DESCRIPTION
Solution: tell it not to use it

Moreover run tests with `py.test -v` which is smarter and produces nicely formatted output. It is installed by default in travis containers.