### PR TITLE
Ensures strings are initialized with the proper empty default

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -837,8 +837,11 @@ class CodeGenerator(object):
             # However if the default value is a CUBA key,
             # we set it to None in the init
             default = content['default']
-            if isinstance(default, str) and default.startswith('CUBA.'):
-                kwargs.append('{key}=None'.format(key=key))
+            if isinstance(default, str):
+                if default.startswith('CUBA.'):
+                    kwargs.append('{key}=None'.format(key=key))
+                else:
+                    kwargs.append('{key}=\"{value}\"'.format(key=key, value=default))
             elif isinstance(default, MutableSequence):
                 # Should not use mutable in the signature
                 kwargs.append('{key}=None'.format(key=key))

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -841,7 +841,8 @@ class CodeGenerator(object):
                 if default.startswith('CUBA.'):
                     kwargs.append('{key}=None'.format(key=key))
                 else:
-                    kwargs.append('{key}=\"{value}\"'.format(key=key, value=default))
+                    kwargs.append('{key}=\"{value}\"'.format(
+                        key=key, value=default))
             elif isinstance(default, MutableSequence):
                 # Should not use mutable in the signature
                 kwargs.append('{key}=None'.format(key=key))


### PR DESCRIPTION
Strings were not initialized properly when they were "plain strings" with no "CUBA" component. This resulted in NAME and DESCRIPTION be set to None, which introduces problems with HDF5 storage.
