### PR TITLE
Problem: rearranging modules is impossible due to absolute imports

### DIFF
--- a/simphony/core/data_container.py
+++ b/simphony/core/data_container.py
@@ -1,4 +1,4 @@
-from simphony.core.cuba import CUBA
+from .cuba import CUBA
 
 
 class DataContainer(dict):

--- a/simphony/cuds/abc_lattice.py
+++ b/simphony/cuds/abc_lattice.py
@@ -1,8 +1,8 @@
 from abc import abstractmethod
 
-from simphony.core.cuds_item import CUDSItem
-from simphony.cuds.abc_dataset import ABCDataset
-from simphony.cuds.utils import deprecated
+from ..core.cuds_item import CUDSItem
+from .abc_dataset import ABCDataset
+from .utils import deprecated
 
 
 class ABCLattice(ABCDataset):

--- a/simphony/cuds/abc_mesh.py
+++ b/simphony/cuds/abc_mesh.py
@@ -1,11 +1,11 @@
 import itertools
 from abc import abstractmethod
 
-from simphony.core.cuds_item import CUDSItem
-from simphony.cuds.abc_dataset import ABCDataset
-from simphony.cuds.utils import deprecated
+from ..core.cuds_item import CUDSItem
+from .abc_dataset import ABCDataset
+from .utils import deprecated
 
-from simphony.cuds.mesh_items import Point, Edge, Face, Cell
+from .mesh_items import Point, Edge, Face, Cell
 
 
 class ABCMesh(ABCDataset):

--- a/simphony/cuds/abc_particles.py
+++ b/simphony/cuds/abc_particles.py
@@ -2,10 +2,10 @@
 from abc import abstractmethod
 import itertools
 
-from simphony.core.cuds_item import CUDSItem
-from simphony.cuds.particles_items import Particle, Bond
-from simphony.cuds.abc_dataset import ABCDataset
-from simphony.cuds.utils import deprecated
+from ..core.cuds_item import CUDSItem
+from .particles_items import Particle, Bond
+from .abc_dataset import ABCDataset
+from .utils import deprecated
 
 
 class ABCParticles(ABCDataset):

--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -1,10 +1,10 @@
 import numpy as np
 
-from simphony.core.cuds_item import CUDSItem
-from simphony.core.data_container import DataContainer
-from simphony.cuds.abc_lattice import ABCLattice
-from simphony.cuds.lattice_items import LatticeNode
-from simphony.cuds.primitive_cell import PrimitiveCell
+from ..core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
+from .abc_lattice import ABCLattice
+from .lattice_items import LatticeNode
+from .primitive_cell import PrimitiveCell
 
 
 class Lattice(ABCLattice):

--- a/simphony/cuds/lattice_items.py
+++ b/simphony/cuds/lattice_items.py
@@ -1,4 +1,4 @@
-from simphony.core import DataContainer
+from ..core import DataContainer
 
 
 class LatticeNode(object):

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -6,10 +6,10 @@ and modify a mesh
 """
 import uuid
 
-import simphony.core.data_container as dc
-from simphony.core.cuds_item import CUDSItem
-from simphony.cuds.abc_mesh import ABCMesh
-from simphony.cuds.mesh_items import Edge, Face, Cell, Point
+from ..core import data_container as dc
+from ..core.cuds_item import CUDSItem
+from .abc_mesh import ABCMesh
+from .mesh_items import Edge, Face, Cell, Point
 
 
 class Mesh(ABCMesh):

--- a/simphony/cuds/mesh_items.py
+++ b/simphony/cuds/mesh_items.py
@@ -1,4 +1,4 @@
-from simphony.core import data_container as dc
+from ..core import data_container as dc
 
 
 class Point(object):

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import uuid
 
-from simphony.core.cuds_item import CUDSItem
-from simphony.core.data_container import DataContainer
-from simphony.cuds import ABCParticles
-from simphony.cuds.particles_items import Particle, Bond
+from ..core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
+from . import ABCParticles
+from .particles_items import Particle, Bond
 
 
 class Particles(ABCParticles):

--- a/simphony/cuds/particles_items.py
+++ b/simphony/cuds/particles_items.py
@@ -1,6 +1,6 @@
 import uuid
 
-from simphony.core import DataContainer
+from ..core import DataContainer
 
 
 class Particle(object):

--- a/simphony/io/data_container_table.py
+++ b/simphony/io/data_container_table.py
@@ -4,11 +4,11 @@ import uuid
 import numpy
 import tables
 
-from simphony.io.data_container_description import Record
-from simphony.io.data_conversion import (convert_from_file_type,
-                                         convert_to_file_type)
-from simphony.core.cuba import CUBA
-from simphony.core.data_container import DataContainer
+from .data_container_description import Record
+from .data_conversion import (convert_from_file_type,
+                              convert_to_file_type)
+from ..core.cuba import CUBA
+from ..core import DataContainer
 
 
 class DataContainerTable(MutableMapping):

--- a/simphony/io/data_conversion.py
+++ b/simphony/io/data_conversion.py
@@ -1,7 +1,7 @@
 import uuid
 
-from simphony.core.keywords import KEYWORDS
-from simphony.core.cuba import CUBA
+from ..core.keywords import KEYWORDS
+from ..core.cuba import CUBA
 
 
 def convert_to_file_type(value, cuba):

--- a/simphony/io/h5_cuds.py
+++ b/simphony/io/h5_cuds.py
@@ -1,12 +1,12 @@
 import tables
 import itertools
 
-from simphony.core.cuds_item import CUDSItem
-from simphony.core.data_container import DataContainer
-from simphony.cuds import ABCParticles, ABCMesh, ABCLattice
-from simphony.io.h5_particles import H5Particles
-from simphony.io.h5_mesh import H5Mesh
-from simphony.io.h5_lattice import H5Lattice
+from ..core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
+from ..cuds import ABCParticles, ABCMesh, ABCLattice
+from .h5_particles import H5Particles
+from .h5_mesh import H5Mesh
+from .h5_lattice import H5Lattice
 
 H5_FILE_VERSION = 3
 

--- a/simphony/io/h5_cuds_items.py
+++ b/simphony/io/h5_cuds_items.py
@@ -3,7 +3,7 @@ from collections import MutableMapping
 
 import tables
 
-from simphony.io.data_container_table import DataContainerTable
+from .data_container_table import DataContainerTable
 
 
 class H5CUDSItems(MutableMapping):

--- a/simphony/io/h5_lattice.py
+++ b/simphony/io/h5_lattice.py
@@ -1,9 +1,9 @@
-from simphony.cuds import ABCLattice, LatticeNode
-from simphony.cuds.primitive_cell import PrimitiveCell, BravaisLattice
-from simphony.io.indexed_data_container_table import IndexedDataContainerTable
-from simphony.io.data_container_description import NoUIDRecord
-from simphony.core.data_container import DataContainer
-from simphony.core.cuds_item import CUDSItem
+from ..cuds import ABCLattice, LatticeNode
+from ..cuds.primitive_cell import PrimitiveCell, BravaisLattice
+from .indexed_data_container_table import IndexedDataContainerTable
+from .data_container_description import NoUIDRecord
+from ..core.data_container import DataContainer
+from ..core.cuds_item import CUDSItem
 
 import numpy as np
 

--- a/simphony/io/h5_mesh.py
+++ b/simphony/io/h5_mesh.py
@@ -7,15 +7,15 @@ and modify a file storing mesh data
 import tables
 import uuid
 
-from simphony.cuds.mesh import ABCMesh
+from ..cuds.mesh import ABCMesh
 
-from simphony.cuds.mesh_items import Edge, Face, Cell, Point
+from ..cuds.mesh_items import Edge, Face, Cell, Point
 
-from simphony.core.data_container import DataContainer
-from simphony.core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
+from ..core.cuds_item import CUDSItem
 
-from simphony.io.data_container_table import DataContainerTable
-from simphony.io.indexed_data_container_table import IndexedDataContainerTable
+from .data_container_table import DataContainerTable
+from .indexed_data_container_table import IndexedDataContainerTable
 
 MAX_POINTS_IN_EDGE = 2
 MAX_POINTS_IN_FACE = 4

--- a/simphony/io/h5_particles.py
+++ b/simphony/io/h5_particles.py
@@ -3,12 +3,12 @@ import uuid
 import tables
 import numpy
 
-from simphony.core.data_container import DataContainer
-from simphony.cuds import ABCParticles
-from simphony.cuds.particles_items import Bond, Particle
-from simphony.core.cuds_item import CUDSItem
-from simphony.io.h5_cuds_items import H5CUDSItems
-from simphony.io.indexed_data_container_table import IndexedDataContainerTable
+from ..core.data_container import DataContainer
+from ..cuds import ABCParticles
+from ..cuds.particles_items import Bond, Particle
+from ..core.cuds_item import CUDSItem
+from .h5_cuds_items import H5CUDSItems
+from .indexed_data_container_table import IndexedDataContainerTable
 
 MAX_NUMBER_PARTICLES_IN_BOND = 20
 

--- a/simphony/io/indexed_data_container_table.py
+++ b/simphony/io/indexed_data_container_table.py
@@ -2,11 +2,11 @@ from collections import Sequence
 
 import numpy
 
-from simphony.io.data_container_description import NoUIDRecord
-from simphony.io.data_conversion import (convert_from_file_type,
-                                         convert_to_file_type)
-from simphony.core.cuba import CUBA
-from simphony.core.data_container import DataContainer
+from .data_container_description import NoUIDRecord
+from .data_conversion import (convert_from_file_type,
+                              convert_to_file_type)
+from ..core.cuba import CUBA
+from ..core.data_container import DataContainer
 
 
 class IndexedDataContainerTable(Sequence):

--- a/simphony/testing/abc_check_engine.py
+++ b/simphony/testing/abc_check_engine.py
@@ -1,16 +1,16 @@
 import abc
 import uuid
 
-from simphony.testing.utils import (
+from .utils import (
     compare_particles_datasets, compare_mesh_datasets,
     compare_lattice_datasets)
 
-from simphony.core.cuba import CUBA
-from simphony.cuds.particles import Particles
-from simphony.cuds.particles_items import Particle
-from simphony.cuds.mesh import Mesh
-from simphony.cuds.mesh_items import Edge, Face, Cell, Point
-from simphony.cuds.lattice import make_cubic_lattice
+from ..core.cuba import CUBA
+from ..cuds.particles import Particles
+from ..cuds.particles_items import Particle
+from ..cuds.mesh import Mesh
+from ..cuds.mesh_items import Edge, Face, Cell, Point
+from ..cuds.lattice import make_cubic_lattice
 
 
 def grouper(iterable, group_size):

--- a/simphony/testing/abc_check_lattice.py
+++ b/simphony/testing/abc_check_lattice.py
@@ -4,13 +4,13 @@ from functools import partial
 import numpy
 from numpy.testing import (assert_array_equal, assert_array_almost_equal)
 
-from simphony.testing.utils import (
+from .utils import (
     create_data_container, compare_data_containers, compare_lattice_nodes)
-from simphony.cuds.lattice import make_triclinic_lattice
-from simphony.cuds.lattice_items import LatticeNode
-from simphony.core.cuds_item import CUDSItem
-from simphony.core.data_container import DataContainer
-from simphony.cuds.primitive_cell import (BravaisLattice, PrimitiveCell)
+from ..cuds.lattice import make_triclinic_lattice
+from ..cuds.lattice_items import LatticeNode
+from ..core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
+from ..cuds.primitive_cell import (BravaisLattice, PrimitiveCell)
 
 
 class CheckLatticeContainer(object):

--- a/simphony/testing/abc_check_mesh.py
+++ b/simphony/testing/abc_check_mesh.py
@@ -3,12 +3,12 @@ import uuid
 import random
 from functools import partial
 
-from simphony.testing.utils import (
+from .utils import (
     create_data_container, create_points, compare_points, compare_elements,
     grouper, compare_data_containers)
-from simphony.cuds.mesh_items import Edge, Face, Cell, Point
-from simphony.core.cuds_item import CUDSItem
-from simphony.core.data_container import DataContainer
+from ..cuds.mesh_items import Edge, Face, Cell, Point
+from ..core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
 
 
 class CheckMeshContainer(object):

--- a/simphony/testing/abc_check_particles.py
+++ b/simphony/testing/abc_check_particles.py
@@ -2,13 +2,13 @@ import abc
 import uuid
 from functools import partial
 
-from simphony.testing.utils import (
+from .utils import (
     compare_particles, create_particles, compare_bonds, create_bonds,
     create_data_container, compare_data_containers,
     create_particles_with_id, create_bonds_with_id)
-from simphony.cuds.particles_items import Bond, Particle
-from simphony.core.cuds_item import CUDSItem
-from simphony.core.data_container import DataContainer
+from ..cuds.particles_items import Bond, Particle
+from ..core.cuds_item import CUDSItem
+from ..core.data_container import DataContainer
 
 
 class CheckParticlesContainer(object):

--- a/simphony/testing/utils.py
+++ b/simphony/testing/utils.py
@@ -5,11 +5,11 @@ import collections
 import numpy
 from numpy.testing import assert_equal
 
-from simphony.core.keywords import KEYWORDS
-from simphony.core.data_container import DataContainer
-from simphony.core.cuba import CUBA
-from simphony.cuds.particles_items import Particle, Bond
-from simphony.cuds.mesh_items import Edge, Face, Cell, Point
+from ..core.keywords import KEYWORDS
+from ..core.data_container import DataContainer
+from ..core.cuba import CUBA
+from ..cuds.particles_items import Particle, Bond
+from ..cuds.mesh_items import Edge, Face, Cell, Point
 
 
 def compare_particles_datasets(particles, reference, testcase=None):

--- a/simphony/tools/lattice_tools.py
+++ b/simphony/tools/lattice_tools.py
@@ -1,7 +1,7 @@
 from itertools import permutations, combinations, product
 
 import numpy
-from simphony.cuds.primitive_cell import BravaisLattice
+from ..cuds.primitive_cell import BravaisLattice
 
 
 def vector_len(vec):


### PR DESCRIPTION
Solution: use relative imports with dot notation

P.S: this is a refactoring PR, nothing new.