### PR TITLE
Fix datacontainer particles, mesh and lattice datasets

### DIFF
--- a/simphony/cuds/lattice.py
+++ b/simphony/cuds/lattice.py
@@ -83,7 +83,7 @@ class Lattice(ABCLattice):
 
     @property
     def data(self):
-        return DataContainer(self._data)
+        return self._data
 
     @data.setter
     def data(self, value):

--- a/simphony/cuds/mesh.py
+++ b/simphony/cuds/mesh.py
@@ -76,7 +76,7 @@ class Mesh(ABCMesh):
 
     @property
     def data(self):
-        return dc.DataContainer(self._data)
+        return self._data
 
     @data.setter
     def data(self, value):

--- a/simphony/cuds/particles.py
+++ b/simphony/cuds/particles.py
@@ -61,7 +61,7 @@ class Particles(ABCParticles):
 
     @property
     def data(self):
-        return DataContainer(self._data)
+        return self._data
 
     @data.setter
     def data(self, new_data):


### PR DESCRIPTION
DS.data should return the data container, and not a copy. This is consistent with dataset elements and metadata generated classes (cuds_item). 
@mehdisadeghi please review.  