### PR TITLE
Revert relocation of validation support code to the module itself

### DIFF
--- a/scripts/validation.template
+++ b/scripts/validation.template
@@ -4,7 +4,43 @@ import warnings
 
 import numpy
 
-from scripts.utils import to_camel_case, without_cuba_prefix
+
+def to_camel_case(text, special={'cuds': 'CUDS'}):
+    """ Convert text to CamelCase (for class name)
+
+    Parameters
+    ----------
+    text : str
+        The text to be converted
+
+    special : dict
+        If any substring of text (lower case) matches a key of `special`,
+        the substring is replaced by the value
+
+    Returns
+    -------
+    result : str
+    """
+
+    def replace_func(matched):
+        # word should be lower case already
+        word = matched.group(0).strip("_")
+        if word in special:
+            # Handle special case
+            return special[word]
+        else:
+            # Capitalise the first character
+            return word[0].upper()+word[1:]
+
+    return re.sub(r'(_?[a-zA-Z]+)', replace_func, text.lower())
+
+
+def without_cuba_prefix(string):
+    """Removes the CUBA. prefix to the string if there."""
+    if is_cuba_key(string):
+        return string[5:]
+
+    return string
 
 
 def check_valid_shape(value, shape, cuba_key):


### PR DESCRIPTION
The validation module must be self-contained.

Reason is that in principle, we should not have scripts in here, and in fact on master, scripts then further imports simphony_metaparser, which is a development package and thus may not be present in a non-dev installation.
