### PR TITLE
Using metadata 0.7.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,4 @@
 exclude = doc/*
 
 [build_meta]
-# Post 0.6.0. 
-# Addition of CFD metadata: 1b64cc80045cf99ffa3594342b44098c1c09be8d
-# Addition of PDE conditions: 19daa41858438d93c79c4957c56b7c78693083a8
-# Addition of PR #129, #130, #132: 5628c9e6e24f9b7ce0bddc9ec7d6dc07b41ec265
-# Addition of inlet-outlet PR #134: 502d4c71847f95a202ccf1a29902e16f2f4d55a8
-# Addition of PR #136: FREE_SLIP_VELOCITY
-# Addition of NUMBER_OF_PHYSICS_STATES and TOTAL_PRESSURE_CONDITION: PR #137 
-#             d3f2de7d01ec8aefa61431d7ca394a828729aa82
-# Addition of PR #139: 96f155b3d1fbae8d1f6e5d629837069609c49611
-repotag = 96f155b3d1fbae8d1f6e5d629837069609c49611
+repotag = 0.7.0


### PR DESCRIPTION
Using 0.7.0 metadata repository. This is the last time we use this architecture. From the next commit, we will integrate metadata in the repo.