### PR TITLE
Moving the dependency of tables to non-extra.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,10 @@ Requirements
 - enum34 >= 1.0.4
 - stevedore >= 1.2.0
 - numpy >= 1.11.1
+- PyTables >= 3.1.1
 
 Optional requirements
 ~~~~~~~~~~~~~~~~~~~~~
-
-To support the HDF5 based native IO:
-
-- PyTables >= 3.1.1
 
 To support the documentation built you need the following packages:
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Requirements
 - enum34 >= 1.0.4
 - stevedore >= 1.2.0
 - numpy >= 1.11.1
-- PyTables >= 3.1.1
+- PyTables >= 3.2.3.1
 
 Optional requirements
 ~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,10 @@ setup(
         "enum34 >= 1.0.4",
         "stevedore >= 1.2.0",
         "numpy >= 1.11",
+        "tables >= 3.2.3.1",
     ],
     extras_require={
-        'H5IO': ["tables ~= 3.2.3.1"],
+        'H5IO': [],
         'CUBAGen': []},
     packages=packages,
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -96,9 +96,6 @@ setup(
         "numpy >= 1.11",
         "tables >= 3.2.3.1",
     ],
-    extras_require={
-        'H5IO': [],
-        'CUBAGen': []},
     packages=packages,
     cmdclass={
         'build_py': Build,


### PR DESCRIPTION
There is no reason except added complexity NOT to have the h5 layer always present.