### PR TITLE
Fix keepdir problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,10 @@ write_version_py()
 # Using a keepdir proved tricky because the compiler cleans up the directory
 # before creating new files. So we create it, let setup detect it, then let
 # the compiler do its magic.
-os.makedirs("simphony/cuds/meta")
+try:
+    os.makedirs("simphony/cuds/meta")
+except OSError:
+    pass
 
 # We cannot use find_packages because we are generating files during build.
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,13 @@ version = '%s'
 
 write_version_py()
 
+# Create the directory for the classes.
+# It must be present because otherwise setup will skip it.
+# Using a keepdir proved tricky because the compiler cleans up the directory
+# before creating new files. So we create it, let setup detect it, then let
+# the compiler do its magic.
+os.makedirs("simphony/cuds/meta")
+
 # We cannot use find_packages because we are generating files during build.
 packages = [
     'bench',


### PR DESCRIPTION
Removes the keepdir file to keep simphony/cuds/meta detectable by the setup script. Replaced with creation of the directory in setup.py.